### PR TITLE
Enable WAL, parallelize SQLite reads, and add SolarDatabase abstraction

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,11 @@
                 <action android:name="android.hardware.usb.action.USB_STATE" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".ScanTriggerReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="com.solar.launcher.action.START_LIBRARY_SCAN" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".MainActivity$MediaBtnReceiver" android:exported="true">
             <intent-filter android:priority="999">
                 <action android:name="android.intent.action.MEDIA_BUTTON" />

--- a/app/src/main/java/com/solar/launcher/LibraryScanner.java
+++ b/app/src/main/java/com/solar/launcher/LibraryScanner.java
@@ -1,0 +1,263 @@
+package com.solar.launcher;
+
+import android.content.SharedPreferences;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Parallel library scan worker.
+ *
+ * <p>Serial filesystem walk + concurrent ID3 extraction via {@link AudioTags}
+ * + single-transaction batch SQLite upsert. This targets the actual scan bottleneck
+ * ({@link android.media.MediaMetadataRetriever}) while keeping SQLite writes serialized.
+ */
+public final class LibraryScanner {
+
+    /** Thread count for tag extraction — bounded to avoid thrashing low-end Y1 storage. */
+    private static final int TAG_THREADS = Math.max(2, Math.min(4,
+            Runtime.getRuntime().availableProcessors()));
+
+    private LibraryScanner() {}
+
+    /** Cancellation and progress hook for the scan worker. */
+    public interface Callback {
+        /** Return true to abort the scan as soon as possible. */
+        boolean isCancelled();
+
+        /** Called roughly every {@code progressInterval} tracks that have been resolved. */
+        void onProgress(int resolvedCount);
+
+        /** Number of resolved tracks between progress callbacks. */
+        int progressInterval();
+    }
+
+    /**
+     * Scan {@code root} for audio files and return a deduplicated list of library items.
+     *
+     * @param root        music root directory
+     * @param store       music metadata cache
+     * @param blacklist   paths to skip
+     * @param prefs       shared prefs for tag overlay
+     * @param seenPaths   populated with every audio file path found on disk (for stale-row purge)
+     * @param cb          cancellation/progress callback
+     * @return resolved song items, never null
+     */
+    public static List<MainActivity.SongItem> scan(File root, MusicLibraryStore store,
+            Set<String> blacklist, SharedPreferences prefs, Set<String> seenPaths, Callback cb) {
+        if (root == null || !root.isDirectory() || cb == null || seenPaths == null) {
+            return Collections.emptyList();
+        }
+        if (cb.isCancelled()) return Collections.emptyList();
+
+        List<File> audioFiles = collectAudioFiles(root, blacklist, seenPaths, cb);
+        if (audioFiles.isEmpty() || cb.isCancelled()) {
+            return Collections.emptyList();
+        }
+
+        List<MainActivity.SongItem> freshItems = new ArrayList<MainActivity.SongItem>();
+        List<File> staleFiles = new ArrayList<File>();
+        partitionByFreshness(audioFiles, store, freshItems, staleFiles);
+
+        if (cb.isCancelled()) return Collections.emptyList();
+
+        List<TagResult> staleResults = readTagsParallel(staleFiles, prefs, cb);
+
+        if (!staleResults.isEmpty()) {
+            persistBatch(staleResults, store);
+        }
+
+        return mergeAndDedup(freshItems, staleResults, cb);
+    }
+
+    private static List<File> collectAudioFiles(File root, Set<String> blacklist,
+            Set<String> seenPaths, Callback cb) {
+        List<File> out = new ArrayList<File>();
+        collectRecursive(root, blacklist, seenPaths, out, cb);
+        return out;
+    }
+
+    private static void collectRecursive(File folder, Set<String> blacklist,
+            Set<String> seenPaths, List<File> out, Callback cb) {
+        if (cb.isCancelled()) return;
+        File[] files = folder.listFiles();
+        if (files == null) return;
+        for (File f : files) {
+            if (cb.isCancelled()) return;
+            if (f.isDirectory()) {
+                collectRecursive(f, blacklist, seenPaths, out, cb);
+            } else if (MainActivity.isAudioFile(f) && !blacklist.contains(f.getAbsolutePath())) {
+                seenPaths.add(f.getAbsolutePath());
+                out.add(f);
+            }
+        }
+    }
+
+    private static void partitionByFreshness(List<File> files, MusicLibraryStore store,
+            List<MainActivity.SongItem> freshOut, List<File> staleOut) {
+        for (File f : files) {
+            MusicLibraryStore.Track cached = store.getFresh(f);
+            if (cached != null) {
+                freshOut.add(songItemFromTrack(cached, f));
+            } else {
+                staleOut.add(f);
+            }
+        }
+    }
+
+    private static List<TagResult> readTagsParallel(List<File> files, SharedPreferences prefs,
+            Callback cb) {
+        if (files.isEmpty()) return Collections.emptyList();
+
+        ExecutorService executor = Executors.newFixedThreadPool(TAG_THREADS,
+                new java.util.concurrent.ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r, "LibraryTagReader");
+                        t.setPriority(Thread.MIN_PRIORITY);
+                        return t;
+                    }
+                });
+
+        List<Future<TagResult>> futures = new ArrayList<Future<TagResult>>(files.size());
+        for (File f : files) {
+            if (cb.isCancelled()) break;
+            futures.add(executor.submit(new TagReader(f, prefs)));
+        }
+        executor.shutdown();
+
+        List<TagResult> out = new ArrayList<TagResult>(futures.size());
+        for (Future<TagResult> future : futures) {
+            if (cb.isCancelled()) break;
+            try {
+                TagResult r = future.get();
+                if (r != null) out.add(r);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (ExecutionException e) {
+                // Ignore individual tag-read failures; original scan did the same.
+            }
+        }
+
+        // Don't let orphan readers extend worker lifetime.
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+
+        return out;
+    }
+
+    private static void persistBatch(List<TagResult> results, MusicLibraryStore store) {
+        List<MusicLibraryStore.Upsert> upserts = new ArrayList<MusicLibraryStore.Upsert>(results.size());
+        for (TagResult r : results) {
+            upserts.add(new MusicLibraryStore.Upsert(r.file, r.title, r.artist, r.album,
+                    r.genre, r.albumArtist, r.durationMs, r.trackNumber));
+        }
+        store.upsertBatch(upserts);
+    }
+
+    private static List<MainActivity.SongItem> mergeAndDedup(List<MainActivity.SongItem> fresh,
+            List<TagResult> stale, Callback cb) {
+        int interval = Math.max(1, cb.progressInterval());
+        Set<String> metaKeys = new HashSet<String>();
+        List<MainActivity.SongItem> out = new ArrayList<MainActivity.SongItem>(
+                fresh.size() + stale.size());
+
+        int resolved = 0;
+        for (MainActivity.SongItem item : fresh) {
+            if (cb.isCancelled()) break;
+            String key = metaKey(item.title, item.artist, "");
+            if (!metaKeys.add(key)) continue;
+            out.add(item);
+            if (++resolved % interval == 0) cb.onProgress(resolved);
+        }
+
+        for (TagResult r : stale) {
+            if (cb.isCancelled()) break;
+            String key = metaKey(r.title, r.artist, r.durationMs);
+            if (!metaKeys.add(key)) continue;
+            out.add(new MainActivity.SongItem(r.file, r.title, r.artist, r.album,
+                    r.genre, r.albumArtist, r.trackNumber));
+            if (++resolved % interval == 0) cb.onProgress(resolved);
+        }
+
+        if (resolved % interval != 0) cb.onProgress(resolved);
+        return out;
+    }
+
+    private static String metaKey(String title, String artist, String durationMs) {
+        return (title + "\0" + artist + "\0" + durationMs).toLowerCase(Locale.US);
+    }
+
+    private static MainActivity.SongItem songItemFromTrack(MusicLibraryStore.Track t, File f) {
+        String genre = t.genre != null && t.genre.trim().length() > 0
+                ? t.genre.trim() : "Unknown Genre";
+        return new MainActivity.SongItem(f, t.title, t.artist, t.album, genre,
+                t.albumArtist, t.trackNumber);
+    }
+
+    private static final class TagReader implements Callable<TagResult> {
+        private final File file;
+        private final SharedPreferences prefs;
+
+        TagReader(File file, SharedPreferences prefs) {
+            this.file = file;
+            this.prefs = prefs;
+        }
+
+        @Override
+        public TagResult call() {
+            try {
+                AudioTags.Info tags = AudioTags.read(file, prefs, AudioTags.READ_SKIP_EMBEDDED_ART);
+                String artist = tags.artist;
+                String album = tags.album;
+                if (artist.isEmpty()) artist = "Unknown Artist";
+                if (album.isEmpty()) album = "Unknown Album";
+                return new TagResult(file, tags.title, artist, album, tags.genre,
+                        tags.albumArtist, tags.durationMs, tags.trackNumber);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+    private static final class TagResult {
+        final File file;
+        final String title;
+        final String artist;
+        final String album;
+        final String genre;
+        final String albumArtist;
+        final String durationMs;
+        final int trackNumber;
+
+        TagResult(File file, String title, String artist, String album, String genre,
+                String albumArtist, String durationMs, int trackNumber) {
+            this.file = file;
+            this.title = title;
+            this.artist = artist;
+            this.album = album;
+            this.genre = genre;
+            this.albumArtist = albumArtist;
+            this.durationMs = durationMs;
+            this.trackNumber = trackNumber;
+        }
+    }
+}

--- a/app/src/main/java/com/solar/launcher/LibraryScanner.java
+++ b/app/src/main/java/com/solar/launcher/LibraryScanner.java
@@ -16,6 +16,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.json.JSONObject;
+
 /**
  * Parallel library scan worker.
  *
@@ -43,6 +45,32 @@ public final class LibraryScanner {
         int progressInterval();
     }
 
+    /** Result of a scan: resolved items plus per-phase timing. */
+    public static final class ScanResult {
+        public final List<MainActivity.SongItem> items;
+        public final long totalMs;
+        public final long collectMs;
+        public final long partitionMs;
+        public final long tagReadMs;
+        public final long persistMs;
+        public final long mergeMs;
+
+        ScanResult(List<MainActivity.SongItem> items, long totalMs, long collectMs,
+                long partitionMs, long tagReadMs, long persistMs, long mergeMs) {
+            this.items = items;
+            this.totalMs = totalMs;
+            this.collectMs = collectMs;
+            this.partitionMs = partitionMs;
+            this.tagReadMs = tagReadMs;
+            this.persistMs = persistMs;
+            this.mergeMs = mergeMs;
+        }
+
+        public JSONObject phases() {
+            return ScanPerfLog.phases(collectMs, partitionMs, tagReadMs, persistMs, mergeMs);
+        }
+    }
+
     /**
      * Scan {@code root} for audio files and return a deduplicated list of library items.
      *
@@ -54,31 +82,49 @@ public final class LibraryScanner {
      * @param cb          cancellation/progress callback
      * @return resolved song items, never null
      */
-    public static List<MainActivity.SongItem> scan(File root, MusicLibraryStore store,
+    public static ScanResult scan(File root, MusicLibraryStore store,
             Set<String> blacklist, SharedPreferences prefs, Set<String> seenPaths, Callback cb) {
         if (root == null || !root.isDirectory() || cb == null || seenPaths == null) {
-            return Collections.emptyList();
+            return emptyResult();
         }
-        if (cb.isCancelled()) return Collections.emptyList();
+        long t0 = System.currentTimeMillis();
+        if (cb.isCancelled()) return emptyResult();
 
+        long t1 = System.currentTimeMillis();
         List<File> audioFiles = collectAudioFiles(root, blacklist, seenPaths, cb);
+        long collectMs = System.currentTimeMillis() - t1;
         if (audioFiles.isEmpty() || cb.isCancelled()) {
-            return Collections.emptyList();
+            return emptyResult();
         }
 
+        t1 = System.currentTimeMillis();
         List<MainActivity.SongItem> freshItems = new ArrayList<MainActivity.SongItem>();
         List<File> staleFiles = new ArrayList<File>();
         partitionByFreshness(audioFiles, store, freshItems, staleFiles);
+        long partitionMs = System.currentTimeMillis() - t1;
 
-        if (cb.isCancelled()) return Collections.emptyList();
+        if (cb.isCancelled()) return emptyResult();
 
+        t1 = System.currentTimeMillis();
         List<TagResult> staleResults = readTagsParallel(staleFiles, prefs, cb);
+        long tagReadMs = System.currentTimeMillis() - t1;
 
+        t1 = System.currentTimeMillis();
         if (!staleResults.isEmpty()) {
             persistBatch(staleResults, store);
         }
+        long persistMs = System.currentTimeMillis() - t1;
 
-        return mergeAndDedup(freshItems, staleResults, cb);
+        t1 = System.currentTimeMillis();
+        List<MainActivity.SongItem> items = mergeAndDedup(freshItems, staleResults, cb);
+        long mergeMs = System.currentTimeMillis() - t1;
+
+        long totalMs = System.currentTimeMillis() - t0;
+        return new ScanResult(items, totalMs, collectMs, partitionMs, tagReadMs, persistMs, mergeMs);
+    }
+
+    private static ScanResult emptyResult() {
+        return new ScanResult(Collections.<MainActivity.SongItem>emptyList(), 0, 0, 0, 0, 0, 0);
     }
 
     private static List<File> collectAudioFiles(File root, Set<String> blacklist,

--- a/app/src/main/java/com/solar/launcher/MainActivity.java
+++ b/app/src/main/java/com/solar/launcher/MainActivity.java
@@ -276,7 +276,7 @@ public class MainActivity extends Activity {
     private Object mediaSessionShim;
     private AvrcpTrackInfoWriter avrcpTrackInfoWriter;
     // 💡 [추가] OS 스캐너를 대체할 '자체 미디어 라이브러리 엔진' 변수들
-    private static class SongItem {
+    static class SongItem {
         File file;
         String title;
         String artist;
@@ -27479,7 +27479,7 @@ public class MainActivity extends Activity {
             containerSettingsItems.getChildAt(1).requestFocus();
         }
     }
-    private boolean isAudioFile(File f) {
+    static boolean isAudioFile(File f) {
         if (f == null || !f.isFile())
             return false;
         String name = f.getName().toLowerCase();
@@ -27515,10 +27515,6 @@ public class MainActivity extends Activity {
     }
 
     // 💡 1. Incremental library scan — SQLite cache + ID3 only for new/changed files.
-    // ponytail: dedupe by path; secondary by title+artist+duration hash — may collapse distinct files
-    private final java.util.HashSet<String> libraryScanPaths = new java.util.HashSet<String>();
-    private final java.util.HashSet<String> libraryScanMetaKeys = new java.util.HashSet<String>();
-
     private static final class LibraryScanResolved {
         SongItem item;
         String metaKey;
@@ -27572,25 +27568,35 @@ public class MainActivity extends Activity {
         if (!userInitiated && tryFinishScanFromFreshCache(gen, userInitiated)) {
             return;
         }
-        libraryScanPaths.clear();
-        libraryScanMetaKeys.clear();
-        java.util.HashSet<String> seenPaths = MusicLibraryStore.newKeepSet();
-        java.util.ArrayList<SongItem> scanned = new java.util.ArrayList<SongItem>();
-        buildCustomLibraryIncremental(rootFolder, store, seenPaths, scanned, gen);
+        final java.util.HashSet<String> seenPaths = MusicLibraryStore.newKeepSet();
+        final java.util.ArrayList<SongItem> scanned = new java.util.ArrayList<SongItem>();
+        final int progressInterval = 25;
+        LibraryScanner.Callback scanCb = new LibraryScanner.Callback() {
+            @Override public boolean isCancelled() { return libraryScanGen != gen; }
+            @Override public void onProgress(int resolvedCount) {
+                libraryScanTrackCount = resolvedCount;
+                postLibraryScanProgress(gen, resolvedCount);
+            }
+            @Override public int progressInterval() { return progressInterval; }
+        };
+        long tScan0 = System.currentTimeMillis();
+        java.util.List<SongItem> found = LibraryScanner.scan(rootFolder, store,
+                blacklist, prefs, seenPaths, scanCb);
+        if (libraryScanGen != gen) {
+            abortLibraryScanWorker(gen);
+            return;
+        }
+        scanned.addAll(found);
         // #region agent log
         try {
             org.json.JSONObject d = new org.json.JSONObject();
             d.put("gen", gen);
             d.put("scanned", scanned.size());
-            d.put("ms", System.currentTimeMillis());
+            d.put("ms", System.currentTimeMillis() - tScan0);
             Debug898913Log.logAlways("MainActivity.runLibraryScanWorker",
-                    "filesystem walk done", "H3,H4", d);
+                    "parallel scan done", "H3,H4", d);
         } catch (Exception ignored) {}
         // #endregion
-        if (libraryScanGen != gen) {
-            abortLibraryScanWorker(gen);
-            return;
-        }
         store.deleteExcept(seenPaths);
         reconcileCustomLibrary(scanned);
         normalizeLibraryAlbumTitles();
@@ -28088,35 +28094,6 @@ public class MainActivity extends Activity {
         });
     }
 
-    private void buildCustomLibraryIncremental(File folder, MusicLibraryStore store,
-            java.util.HashSet<String> seenPaths, java.util.ArrayList<SongItem> out, int gen) {
-        if (libraryScanGen != gen) return;
-        File[] files = folder.listFiles();
-        if (files == null) return;
-        for (File f : files) {
-            if (libraryScanGen != gen) return;
-            if (f.isDirectory()) {
-                buildCustomLibraryIncremental(f, store, seenPaths, out, gen);
-            } else if (isAudioFile(f)) {
-                if (blacklist.contains(f.getAbsolutePath())) continue;
-                seenPaths.add(f.getAbsolutePath());
-                String normPath = f.getAbsolutePath().toLowerCase(java.util.Locale.US);
-                if (!libraryScanPaths.add(normPath)) continue;
-                LibraryScanResolved resolved = resolveSongItemForScan(f, store, gen);
-                if (resolved == null || resolved.item == null) continue;
-                if (!libraryScanMetaKeys.add(resolved.metaKey)) continue;
-                out.add(resolved.item);
-                int n = out.size();
-                if (n != libraryScanTrackCount) {
-                    libraryScanTrackCount = n;
-                    if (n % 25 == 0) {
-                        postLibraryScanProgress(gen, n);
-                    }
-                }
-            }
-        }
-    }
-
     private LibraryScanResolved resolveSongItemForScan(File f, MusicLibraryStore store, int gen) {
         try {
             if (libraryScanGen != gen) return null;
@@ -28127,9 +28104,8 @@ public class MainActivity extends Activity {
             String albumArtist;
             String durationMs;
             int trackNumber = 0;
-            if (store.isFresh(f)) {
-                MusicLibraryStore.Track cached = store.get(f.getAbsolutePath());
-                if (cached == null) return null;
+            MusicLibraryStore.Track cached = store.getFresh(f);
+            if (cached != null) {
                 title = cached.title;
                 artist = cached.artist;
                 album = cached.album;

--- a/app/src/main/java/com/solar/launcher/MainActivity.java
+++ b/app/src/main/java/com/solar/launcher/MainActivity.java
@@ -27580,23 +27580,25 @@ public class MainActivity extends Activity {
             @Override public int progressInterval() { return progressInterval; }
         };
         long tScan0 = System.currentTimeMillis();
-        java.util.List<SongItem> found = LibraryScanner.scan(rootFolder, store,
+        LibraryScanner.ScanResult result = LibraryScanner.scan(rootFolder, store,
                 blacklist, prefs, seenPaths, scanCb);
         if (libraryScanGen != gen) {
             abortLibraryScanWorker(gen);
             return;
         }
-        scanned.addAll(found);
+        scanned.addAll(result.items);
+        long scanMs = System.currentTimeMillis() - tScan0;
         // #region agent log
         try {
             org.json.JSONObject d = new org.json.JSONObject();
             d.put("gen", gen);
             d.put("scanned", scanned.size());
-            d.put("ms", System.currentTimeMillis() - tScan0);
+            d.put("ms", scanMs);
             Debug898913Log.logAlways("MainActivity.runLibraryScanWorker",
                     "parallel scan done", "H3,H4", d);
         } catch (Exception ignored) {}
         // #endregion
+        // Perf log: full scan timing is recorded after album-art ingest below.
         store.deleteExcept(seenPaths);
         reconcileCustomLibrary(scanned);
         normalizeLibraryAlbumTitles();
@@ -27617,6 +27619,7 @@ public class MainActivity extends Activity {
                     "scan ui finish scheduled, art async", "H5", d);
         } catch (Exception ignored) {}
         // #endregion
+        ScanPerfLog.record(scanned.size(), scanMs, result.phases());
         if (libraryScanGen != gen) {
             abortLibraryScanWorker(gen);
             return;

--- a/app/src/main/java/com/solar/launcher/MainActivity.java
+++ b/app/src/main/java/com/solar/launcher/MainActivity.java
@@ -8216,6 +8216,11 @@ public class MainActivity extends Activity {
     private void handleLaunchIntentExtras() {
         Intent intent = getIntent();
         if (intent == null) return;
+        if (intent.getBooleanExtra(ScanTriggerReceiver.EXTRA_TRIGGER, false)) {
+            intent.removeExtra(ScanTriggerReceiver.EXTRA_TRIGGER);
+            scanMediaLibraryAsync();
+            return;
+        }
         boolean open = intent.getBooleanExtra("open_webserver", false);
         if (!open) {
             String s = intent.getStringExtra("open_webserver");

--- a/app/src/main/java/com/solar/launcher/MusicLibraryStore.java
+++ b/app/src/main/java/com/solar/launcher/MusicLibraryStore.java
@@ -28,6 +28,30 @@ public class MusicLibraryStore extends SolarDbHelper {
     private static MusicLibraryStore instance;
     private boolean legacyTrackNumbersMigrated;
 
+    /** Batch upsert input — avoids per-row method-call overhead during scans. */
+    public static final class Upsert {
+        public final File file;
+        public final String title;
+        public final String artist;
+        public final String album;
+        public final String genre;
+        public final String albumArtist;
+        public final String durationMs;
+        public final int trackNumber;
+
+        public Upsert(File file, String title, String artist, String album,
+                String genre, String albumArtist, String durationMs, int trackNumber) {
+            this.file = file;
+            this.title = title != null ? title : "";
+            this.artist = artist != null ? artist : "";
+            this.album = album != null ? album : "";
+            this.genre = genre != null ? genre : "";
+            this.albumArtist = albumArtist != null ? albumArtist : "";
+            this.durationMs = durationMs != null ? durationMs : "";
+            this.trackNumber = trackNumber;
+        }
+    }
+
     /** Cached row — maps to {@link MainActivity}'s SongItem fields. */
     public static final class Track {
         public final String path;
@@ -168,6 +192,17 @@ public class MusicLibraryStore extends SolarDbHelper {
         return null;
     }
 
+    /**
+     * Cached track only when it matches the current file stat.
+     * Single DB lookup instead of {@link #isFresh(File)} + {@link #get(String)}.
+     */
+    public Track getFresh(File file) {
+        if (file == null || !file.isFile()) return null;
+        Track t = get(file.getAbsolutePath());
+        if (t == null) return null;
+        return t.mtime == file.lastModified() && t.size == file.length() ? t : null;
+    }
+
     /** True when cached row matches current file stat — skip MediaMetadataRetriever. */
     public boolean isFresh(File file) {
         migrateLegacyZeroTrackNumbers();
@@ -194,6 +229,43 @@ public class MusicLibraryStore extends SolarDbHelper {
                 "INSERT OR REPLACE INTO tracks"
                         + " (path,mtime,size,title,artist,album,genre,album_artist,duration_ms,track_number)"
                         + " VALUES (?,?,?,?,?,?,?,?,?,?)");
+        try {
+            bindUpsert(st, file, title, artist, album, genre, albumArtist, durationMs, trackNumber);
+            st.executeInsert();
+        } finally {
+            st.close();
+        }
+    }
+
+    /**
+     * Batch upsert inside a single transaction — much faster than one transaction per row
+     * when importing thousands of tracks during a library scan.
+     */
+    public void upsertBatch(List<Upsert> tracks) {
+        if (tracks == null || tracks.isEmpty()) return;
+        SQLiteDatabase db = getWritableDatabase();
+        db.beginTransaction();
+        SQLiteStatement st = db.compileStatement(
+                "INSERT OR REPLACE INTO tracks"
+                        + " (path,mtime,size,title,artist,album,genre,album_artist,duration_ms,track_number)"
+                        + " VALUES (?,?,?,?,?,?,?,?,?,?)");
+        try {
+            for (Upsert t : tracks) {
+                bindUpsert(st, t.file, t.title, t.artist, t.album, t.genre,
+                        t.albumArtist, t.durationMs, t.trackNumber);
+                st.executeInsert();
+                st.clearBindings();
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+            st.close();
+        }
+    }
+
+    private static void bindUpsert(SQLiteStatement st, File file, String title, String artist,
+            String album, String genre, String albumArtist, String durationMs, int trackNumber) {
+        if (trackNumber == 0) trackNumber = -1;
         st.bindString(1, file.getAbsolutePath());
         st.bindLong(2, file.lastModified());
         st.bindLong(3, file.length());
@@ -204,7 +276,6 @@ public class MusicLibraryStore extends SolarDbHelper {
         st.bindString(8, albumArtist != null ? albumArtist : "");
         st.bindString(9, durationMs != null ? durationMs : "");
         st.bindLong(10, trackNumber);
-        st.executeInsert();
     }
 
     /** Wipe all cached track rows — Settings reset / cache clear. */

--- a/app/src/main/java/com/solar/launcher/MusicLibraryStore.java
+++ b/app/src/main/java/com/solar/launcher/MusicLibraryStore.java
@@ -3,8 +3,10 @@ package com.solar.launcher;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteStatement;
+
+import com.solar.launcher.db.SolarDatabase;
+import com.solar.launcher.db.SolarDbHelper;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -19,7 +21,7 @@ import java.util.Set;
  * SQLite cache for local Music library metadata — avoids re-reading ID3 on every scan.
  * ponytail: keyed by path + mtime + size; stale rows purged after each walk.
  */
-public class MusicLibraryStore extends SQLiteOpenHelper {
+public class MusicLibraryStore extends SolarDbHelper {
     private static final String DB_NAME = "music_library.db";
     private static final int DB_VERSION = 3;
 
@@ -66,7 +68,11 @@ public class MusicLibraryStore extends SQLiteOpenHelper {
     }
 
     private MusicLibraryStore(Context ctx) {
-        super(ctx.getApplicationContext(), DB_NAME, null, DB_VERSION);
+        this(ctx, true);
+    }
+
+    private MusicLibraryStore(Context ctx, boolean walEnabled) {
+        super(ctx.getApplicationContext(), DB_NAME, DB_VERSION, walEnabled);
     }
 
     public static synchronized MusicLibraryStore getInstance(Context ctx) {
@@ -87,7 +93,7 @@ public class MusicLibraryStore extends SQLiteOpenHelper {
     public static MusicLibraryStore openForTest(Context ctx) {
         resetInstanceForTest();
         final SQLiteDatabase[] mem = new SQLiteDatabase[1];
-        instance = new MusicLibraryStore(ctx.getApplicationContext()) {
+        instance = new MusicLibraryStore(ctx.getApplicationContext(), false) {
             @Override
             public synchronized SQLiteDatabase getWritableDatabase() {
                 if (mem[0] == null) {
@@ -106,7 +112,7 @@ public class MusicLibraryStore extends SQLiteOpenHelper {
     }
 
     @Override
-    public void onCreate(SQLiteDatabase db) {
+    public void onCreate(SolarDatabase db) {
         db.execSQL("CREATE TABLE tracks ("
                 + "path TEXT PRIMARY KEY,"
                 + "mtime INTEGER NOT NULL DEFAULT 0,"
@@ -122,7 +128,7 @@ public class MusicLibraryStore extends SQLiteOpenHelper {
     }
 
     @Override
-    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    public void onUpgrade(SolarDatabase db, int oldVersion, int newVersion) {
         if (oldVersion < 2) {
             db.execSQL("ALTER TABLE tracks ADD COLUMN track_number INTEGER NOT NULL DEFAULT 0");
         }
@@ -210,23 +216,43 @@ public class MusicLibraryStore extends SQLiteOpenHelper {
     /** Remove DB rows whose paths were not seen in the latest filesystem walk. */
     public void deleteExcept(Set<String> keepPaths) {
         if (keepPaths == null) return;
+        if (keepPaths.isEmpty()) {
+            clearAll();
+            return;
+        }
         SQLiteDatabase db = getWritableDatabase();
         db.beginTransaction();
+        Cursor c = null;
         try {
-            Cursor c = db.query("tracks", new String[] { "path" }, null, null, null, null, null);
+            c = db.query("tracks", new String[] { "path" }, null, null, null, null, null);
             List<String> stale = new ArrayList<String>();
             while (c.moveToNext()) {
                 String p = c.getString(0);
                 if (!keepPaths.contains(p)) stale.add(p);
             }
             c.close();
-            for (String p : stale) {
-                db.delete("tracks", "path=?", new String[] { p });
+            c = null;
+            // Batch stale paths into a single DELETE per chunk (SQLite max host params is 999).
+            final int chunk = 500;
+            for (int i = 0; i < stale.size(); i += chunk) {
+                int end = Math.min(i + chunk, stale.size());
+                String[] args = stale.subList(i, end).toArray(new String[0]);
+                db.delete("tracks", "path IN (" + placeholders(args.length) + ")", args);
             }
             db.setTransactionSuccessful();
         } finally {
+            if (c != null) c.close();
             db.endTransaction();
         }
+    }
+
+    private static String placeholders(int count) {
+        StringBuilder sb = new StringBuilder(count * 2);
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append(',');
+            sb.append('?');
+        }
+        return sb.toString();
     }
 
     /** path → durationSec for Soulseek share scan (avoids second MMR pass). */

--- a/app/src/main/java/com/solar/launcher/ScanPerfLog.java
+++ b/app/src/main/java/com/solar/launcher/ScanPerfLog.java
@@ -1,0 +1,117 @@
+package com.solar.launcher;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Lightweight scan-performance logger.
+ *
+ * <p>Writes JSON lines to {@code /storage/sdcard0/solar/scan-perf.log} and logcat tag
+ * {@code SolarScanPerf} so the creator can measure library-scan timing on real Y1 hardware.
+ * The file is append-only and rotated when it exceeds 256 KB.</p>
+ */
+public final class ScanPerfLog {
+
+    private static final String TAG = "SolarScanPerf";
+    private static final String FILE = "/storage/sdcard0/solar/scan-perf.log";
+    private static final long MAX_SIZE = 256 * 1024;
+
+    private static final AtomicReference<LastScan> LAST = new AtomicReference<LastScan>();
+
+    private ScanPerfLog() {}
+
+    /** In-memory snapshot of the most recent scan. */
+    public static final class LastScan {
+        public final long timestamp;
+        public final int trackCount;
+        public final long totalMs;
+        public final String phaseBreakdown;
+
+        public LastScan(long timestamp, int trackCount, long totalMs, String phaseBreakdown) {
+            this.timestamp = timestamp;
+            this.trackCount = trackCount;
+            this.totalMs = totalMs;
+            this.phaseBreakdown = phaseBreakdown;
+        }
+    }
+
+    /**
+     * Record a scan timing event.
+     *
+     * @param tracks   number of tracks resolved
+     * @param totalMs  total scan time in milliseconds
+     * @param phases   JSON object with per-phase milliseconds
+     */
+    public static void record(int tracks, long totalMs, JSONObject phases) {
+        long now = System.currentTimeMillis();
+        LastScan snapshot = new LastScan(now, tracks, totalMs,
+                phases != null ? phases.toString() : "{}");
+        LAST.set(snapshot);
+
+        try {
+            JSONObject o = new JSONObject();
+            o.put("timestamp", now);
+            o.put("tracks", tracks);
+            o.put("totalMs", totalMs);
+            o.put("phases", phases != null ? phases : new JSONObject());
+
+            String line = o.toString();
+            Log.i(TAG, line);
+            appendLine(line);
+        } catch (Exception ignored) {
+            // Never crash the scan path for perf logging.
+        }
+    }
+
+    /** Snapshot of the most recent scan; null until a scan completes. */
+    public static LastScan last() {
+        return LAST.get();
+    }
+
+    /** Reset the in-memory snapshot (e.g. after a settings reset). */
+    public static void clear() {
+        LAST.set(null);
+    }
+
+    private static void appendLine(String line) {
+        try {
+            File f = new File(FILE);
+            File parent = f.getParentFile();
+            if (parent != null && !parent.exists()) parent.mkdirs();
+            if (f.length() > MAX_SIZE) {
+                File backup = new File(FILE + ".old");
+                if (backup.exists()) backup.delete();
+                f.renameTo(backup);
+            }
+            PrintWriter pw = new PrintWriter(new BufferedWriter(new FileWriter(f, true)));
+            pw.println(line);
+            pw.close();
+        } catch (IOException e) {
+            Log.w(TAG, "append failed: " + e.getMessage());
+        }
+    }
+
+    /** Build a phase timing object for LibraryScanner. */
+    public static JSONObject phases(long collectMs, long partitionMs, long tagReadMs,
+            long persistMs, long mergeMs) {
+        JSONObject p = new JSONObject();
+        try {
+            p.put("collectMs", collectMs);
+            p.put("partitionMs", partitionMs);
+            p.put("tagReadMs", tagReadMs);
+            p.put("persistMs", persistMs);
+            p.put("mergeMs", mergeMs);
+        } catch (JSONException ignored) {}
+        return p;
+    }
+}

--- a/app/src/main/java/com/solar/launcher/ScanTriggerReceiver.java
+++ b/app/src/main/java/com/solar/launcher/ScanTriggerReceiver.java
@@ -1,0 +1,31 @@
+package com.solar.launcher;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * ADB-triggerable library scan entry point for performance testing.
+ *
+ * <p>Usage:
+ * <pre>
+ *   adb shell am broadcast -a com.solar.launcher.action.START_LIBRARY_SCAN \
+ *       -n com.solar.launcher/.ScanTriggerReceiver
+ * </pre>
+ *
+ * The receiver launches MainActivity with a flag that causes it to start a scan.
+ * For cold-start/full-scan measurements, clear the music library database first.
+ */
+public final class ScanTriggerReceiver extends BroadcastReceiver {
+
+    static final String ACTION = "com.solar.launcher.action.START_LIBRARY_SCAN";
+    static final String EXTRA_TRIGGER = "solar_trigger_scan";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Intent launch = new Intent(context, MainActivity.class);
+        launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        launch.putExtra(EXTRA_TRIGGER, true);
+        context.startActivity(launch);
+    }
+}

--- a/app/src/main/java/com/solar/launcher/SolarWebServer.java
+++ b/app/src/main/java/com/solar/launcher/SolarWebServer.java
@@ -148,6 +148,7 @@ public class SolarWebServer extends Thread {
                             "</style></head><body>" +
                             "<h2>🎧 Solar Wireless Upload</h2>" +
                             "<p><a href='/deezer' style='color:#0ff'>Deezer account setup →</a></p>" +
+                            "<p><a href='/scan_stats' style='color:#0ff'>Last library scan stats →</a></p>" +
                             "<div class='box'><h3>1. Create Folder</h3>" +
                             "<input type='text' id='fName' placeholder='e.g., Pop, Jazz'>" +
                             "<button onclick='createFolder()'>Create</button></div>" +
@@ -253,6 +254,28 @@ public class SolarWebServer extends Thread {
                         }
                         writeDeezerSetupPage(os, msg);
                     }
+                }
+                else if (method.equals("GET") && path.equals("/scan_stats")) {
+                    ScanPerfLog.LastScan last = ScanPerfLog.last();
+                    org.json.JSONObject d = new org.json.JSONObject();
+                    try {
+                        if (last != null) {
+                            d.put("timestamp", last.timestamp);
+                            d.put("trackCount", last.trackCount);
+                            d.put("totalMs", last.totalMs);
+                            d.put("phases", new org.json.JSONObject(last.phaseBreakdown));
+                            d.put("tracksPerSecond",
+                                    last.totalMs > 0 ? (last.trackCount * 1000f / last.totalMs) : 0f);
+                        } else {
+                            d.put("timestamp", org.json.JSONObject.NULL);
+                            d.put("trackCount", 0);
+                            d.put("totalMs", 0);
+                            d.put("phases", new org.json.JSONObject());
+                            d.put("tracksPerSecond", 0f);
+                        }
+                    } catch (Exception ignored) {}
+                    String response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" + d.toString();
+                    os.write(response.getBytes("UTF-8"));
                 }
                 else if (method.equals("POST") && path.startsWith("/upload")) {
                     String q = path.split("\\?")[1];

--- a/app/src/main/java/com/solar/launcher/db/SolarCursor.java
+++ b/app/src/main/java/com/solar/launcher/db/SolarCursor.java
@@ -1,0 +1,27 @@
+package com.solar.launcher.db;
+
+/**
+ * Cursor abstraction matching the small surface actually used by Solar stores.
+ * Keeps the pilot store ({@link com.solar.launcher.radio.fm.FmPresetStore}) portable
+ * so a libSQL-backed engine can be plugged in later.
+ */
+public interface SolarCursor {
+
+    boolean moveToFirst();
+
+    boolean moveToNext();
+
+    long getLong(int columnIndex);
+
+    int getInt(int columnIndex);
+
+    String getString(int columnIndex);
+
+    boolean isNull(int columnIndex);
+
+    int getColumnIndex(String columnName);
+
+    void close();
+
+    boolean isClosed();
+}

--- a/app/src/main/java/com/solar/launcher/db/SolarDatabase.java
+++ b/app/src/main/java/com/solar/launcher/db/SolarDatabase.java
@@ -1,0 +1,40 @@
+package com.solar.launcher.db;
+
+/**
+ * Database handle abstraction. Mirrors the subset of {@link android.database.sqlite.SQLiteDatabase}
+ * actually used by Solar stores, creating an insertion point for a future libSQL engine without
+ * rewriting every call site.
+ *
+ * <p>Instances are short-lived handles borrowed from a {@link SolarDbHelper}; closing them
+ * does not close the underlying database connection.</p>
+ */
+public interface SolarDatabase {
+
+    /** Convenience query with column projection and sort order. */
+    SolarCursor query(String table, String[] columns, String selection,
+            String[] selectionArgs, String sortOrder);
+
+    /** Raw SQL query. */
+    SolarCursor rawQuery(String sql, String[] selectionArgs);
+
+    /** Execute a raw SQL statement. */
+    void execSQL(String sql);
+
+    /** Execute a raw SQL statement with bound arguments. */
+    void execSQL(String sql, Object[] bindArgs);
+
+    /** Delete rows matching the where clause. */
+    int delete(String table, String whereClause, String[] whereArgs);
+
+    /** Begin a transaction. */
+    void beginTransaction();
+
+    /** Mark the current transaction successful. */
+    void setTransactionSuccessful();
+
+    /** End the current transaction. */
+    void endTransaction();
+
+    /** True if currently inside a transaction. */
+    boolean inTransaction();
+}

--- a/app/src/main/java/com/solar/launcher/db/SolarDbHelper.java
+++ b/app/src/main/java/com/solar/launcher/db/SolarDbHelper.java
@@ -1,0 +1,71 @@
+package com.solar.launcher.db;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import com.solar.launcher.db.android.AndroidSolarDatabase;
+
+/**
+ * Base helper for Solar SQLite caches. Enables WAL so reads can run in parallel
+ * via Android's connection pool, and applies sane pragmas for durability vs speed.
+ *
+ * <p>Subclasses get a modernized SQLite setup without changing call sites.
+ * The helper intentionally stays compatible with {@code minSdk 17}; a future
+ * libSQL engine can be swapped in behind {@link SolarDatabase} pilots.</p>
+ */
+public abstract class SolarDbHelper extends SQLiteOpenHelper {
+
+    private final boolean walEnabled;
+
+    protected SolarDbHelper(Context context, String name, int version) {
+        this(context, name, version, true);
+    }
+
+    protected SolarDbHelper(Context context, String name, int version, boolean walEnabled) {
+        super(context.getApplicationContext(), name, null, version);
+        this.walEnabled = walEnabled;
+        if (walEnabled) {
+            setWriteAheadLoggingEnabled(true);
+        }
+    }
+
+    @Override
+    public void onOpen(SQLiteDatabase db) {
+        super.onOpen(db);
+        if (!walEnabled) return;
+        // WAL already allows concurrent readers; NORMAL sync is durable enough
+        // for a local media cache while keeping writes from fsync-blocking.
+        db.execSQL("PRAGMA synchronous=NORMAL");
+        // Keep WAL files from growing without bound on the Y1's limited storage.
+        db.execSQL("PRAGMA journal_size_limit=1048576");
+        // Checkpoint after every 100 pages — balances read latency vs write throughput.
+        db.execSQL("PRAGMA wal_autocheckpoint=100");
+    }
+
+    /** Borrow a readable database handle wrapped for portability. */
+    public SolarDatabase openReadable() {
+        return new AndroidSolarDatabase(getReadableDatabase());
+    }
+
+    /** Borrow a writable database handle wrapped for portability. */
+    public SolarDatabase openWritable() {
+        return new AndroidSolarDatabase(getWritableDatabase());
+    }
+
+    @Override
+    public final void onCreate(SQLiteDatabase db) {
+        onCreate(new AndroidSolarDatabase(db));
+    }
+
+    /** Create tables using the portable {@link SolarDatabase} API. */
+    public abstract void onCreate(SolarDatabase db);
+
+    @Override
+    public final void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        onUpgrade(new AndroidSolarDatabase(db), oldVersion, newVersion);
+    }
+
+    /** Upgrade tables using the portable {@link SolarDatabase} API. */
+    public abstract void onUpgrade(SolarDatabase db, int oldVersion, int newVersion);
+}

--- a/app/src/main/java/com/solar/launcher/db/android/AndroidSolarCursor.java
+++ b/app/src/main/java/com/solar/launcher/db/android/AndroidSolarCursor.java
@@ -1,0 +1,60 @@
+package com.solar.launcher.db.android;
+
+import android.database.Cursor;
+
+import com.solar.launcher.db.SolarCursor;
+
+/** Android {@link Cursor} wrapper implementing the Solar cursor contract. */
+public final class AndroidSolarCursor implements SolarCursor {
+
+    private final Cursor cursor;
+
+    public AndroidSolarCursor(Cursor cursor) {
+        this.cursor = cursor;
+    }
+
+    @Override
+    public boolean moveToFirst() {
+        return cursor.moveToFirst();
+    }
+
+    @Override
+    public boolean moveToNext() {
+        return cursor.moveToNext();
+    }
+
+    @Override
+    public long getLong(int columnIndex) {
+        return cursor.getLong(columnIndex);
+    }
+
+    @Override
+    public int getInt(int columnIndex) {
+        return cursor.getInt(columnIndex);
+    }
+
+    @Override
+    public String getString(int columnIndex) {
+        return cursor.getString(columnIndex);
+    }
+
+    @Override
+    public boolean isNull(int columnIndex) {
+        return cursor.isNull(columnIndex);
+    }
+
+    @Override
+    public int getColumnIndex(String columnName) {
+        return cursor.getColumnIndex(columnName);
+    }
+
+    @Override
+    public void close() {
+        cursor.close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return cursor.isClosed();
+    }
+}

--- a/app/src/main/java/com/solar/launcher/db/android/AndroidSolarDatabase.java
+++ b/app/src/main/java/com/solar/launcher/db/android/AndroidSolarDatabase.java
@@ -1,0 +1,63 @@
+package com.solar.launcher.db.android;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.solar.launcher.db.SolarCursor;
+import com.solar.launcher.db.SolarDatabase;
+
+/** Android {@link SQLiteDatabase} wrapper implementing the Solar database contract. */
+public final class AndroidSolarDatabase implements SolarDatabase {
+
+    private final SQLiteDatabase db;
+
+    public AndroidSolarDatabase(SQLiteDatabase db) {
+        this.db = db;
+    }
+
+    @Override
+    public SolarCursor query(String table, String[] columns, String selection,
+            String[] selectionArgs, String sortOrder) {
+        return new AndroidSolarCursor(db.query(table, columns, selection,
+                selectionArgs, null, null, sortOrder));
+    }
+
+    @Override
+    public SolarCursor rawQuery(String sql, String[] selectionArgs) {
+        return new AndroidSolarCursor(db.rawQuery(sql, selectionArgs));
+    }
+
+    @Override
+    public void execSQL(String sql) {
+        db.execSQL(sql);
+    }
+
+    @Override
+    public void execSQL(String sql, Object[] bindArgs) {
+        db.execSQL(sql, bindArgs);
+    }
+
+    @Override
+    public int delete(String table, String whereClause, String[] whereArgs) {
+        return db.delete(table, whereClause, whereArgs);
+    }
+
+    @Override
+    public void beginTransaction() {
+        db.beginTransaction();
+    }
+
+    @Override
+    public void setTransactionSuccessful() {
+        db.setTransactionSuccessful();
+    }
+
+    @Override
+    public void endTransaction() {
+        db.endTransaction();
+    }
+
+    @Override
+    public boolean inTransaction() {
+        return db.inTransaction();
+    }
+}

--- a/app/src/main/java/com/solar/launcher/radio/fm/FmPresetStore.java
+++ b/app/src/main/java/com/solar/launcher/radio/fm/FmPresetStore.java
@@ -1,15 +1,16 @@
 package com.solar.launcher.radio.fm;
 
 import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import com.solar.launcher.db.SolarCursor;
+import com.solar.launcher.db.SolarDatabase;
+import com.solar.launcher.db.SolarDbHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /** Saved FM stations — freq in kHz + optional label. */
-public final class FmPresetStore extends SQLiteOpenHelper {
+public final class FmPresetStore extends SolarDbHelper {
   private static final String DB = "fm_presets.db";
   private static final int VERSION = 1;
 
@@ -28,7 +29,7 @@ public final class FmPresetStore extends SQLiteOpenHelper {
   }
 
   private FmPresetStore(Context ctx) {
-    super(ctx.getApplicationContext(), DB, null, VERSION);
+    super(ctx.getApplicationContext(), DB, VERSION);
   }
 
   public static synchronized FmPresetStore getInstance(Context ctx) {
@@ -46,7 +47,7 @@ public final class FmPresetStore extends SQLiteOpenHelper {
   }
 
   @Override
-  public void onCreate(SQLiteDatabase db) {
+  public void onCreate(SolarDatabase db) {
     db.execSQL(
         "CREATE TABLE presets ("
             + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -56,15 +57,15 @@ public final class FmPresetStore extends SQLiteOpenHelper {
   }
 
   @Override
-  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+  public void onUpgrade(SolarDatabase db, int oldVersion, int newVersion) {
     db.execSQL("DROP TABLE IF EXISTS presets");
     onCreate(db);
   }
 
-  public synchronized List<Preset> listAll() {
-    SQLiteDatabase db = getReadableDatabase();
-    Cursor c =
-        db.query("presets", new String[] {"id", "freq_khz", "label"}, null, null, null, null,
+  public List<Preset> listAll() {
+    SolarDatabase db = openReadable();
+    SolarCursor c =
+        db.query("presets", new String[] {"id", "freq_khz", "label"}, null, null,
             "freq_khz ASC");
     List<Preset> out = new ArrayList<Preset>();
     try {
@@ -79,12 +80,12 @@ public final class FmPresetStore extends SQLiteOpenHelper {
   }
 
   public synchronized long upsert(int freqKhz, String label) {
-    SQLiteDatabase db = getWritableDatabase();
+    SolarDatabase db = openWritable();
     db.execSQL(
         "INSERT OR REPLACE INTO presets (id, freq_khz, label) VALUES ("
             + "(SELECT id FROM presets WHERE freq_khz=?), ?, ?)",
         new Object[] {freqKhz, freqKhz, label != null ? label : ""});
-    Cursor c = db.rawQuery("SELECT id FROM presets WHERE freq_khz=?", new String[] {
+    SolarCursor c = db.rawQuery("SELECT id FROM presets WHERE freq_khz=?", new String[] {
       Integer.toString(freqKhz)
     });
     try {
@@ -95,17 +96,17 @@ public final class FmPresetStore extends SQLiteOpenHelper {
   }
 
   public synchronized boolean delete(int freqKhz) {
-    return getWritableDatabase().delete("presets", "freq_khz=?", new String[] {
+    return openWritable().delete("presets", "freq_khz=?", new String[] {
           Integer.toString(freqKhz)
         })
         > 0;
   }
 
-  public synchronized Preset findByFreq(int freqKhz) {
-    SQLiteDatabase db = getReadableDatabase();
-    Cursor c =
+  public Preset findByFreq(int freqKhz) {
+    SolarDatabase db = openReadable();
+    SolarCursor c =
         db.query("presets", new String[] {"id", "freq_khz", "label"}, "freq_khz=?",
-            new String[] {Integer.toString(freqKhz)}, null, null, null);
+            new String[] {Integer.toString(freqKhz)}, null);
     try {
       if (!c.moveToFirst()) return null;
       return new Preset(c.getLong(0), c.getInt(1), c.isNull(2) ? "" : c.getString(2));

--- a/app/src/main/java/com/solar/launcher/radio/net/InternetRadioFavorites.java
+++ b/app/src/main/java/com/solar/launcher/radio/net/InternetRadioFavorites.java
@@ -1,15 +1,16 @@
 package com.solar.launcher.radio.net;
 
 import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import com.solar.launcher.db.SolarCursor;
+import com.solar.launcher.db.SolarDatabase;
+import com.solar.launcher.db.SolarDbHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /** Saved internet radio stations keyed by Radio Browser stationuuid. */
-public final class InternetRadioFavorites extends SQLiteOpenHelper {
+public final class InternetRadioFavorites extends SolarDbHelper {
   private static final String DB = "internet_radio_favorites.db";
   private static final int VERSION = 1;
 
@@ -32,7 +33,7 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
   }
 
   private InternetRadioFavorites(Context ctx) {
-    super(ctx.getApplicationContext(), DB, null, VERSION);
+    super(ctx.getApplicationContext(), DB, VERSION);
   }
 
   public static synchronized InternetRadioFavorites getInstance(Context ctx) {
@@ -50,7 +51,7 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
   }
 
   @Override
-  public void onCreate(SQLiteDatabase db) {
+  public void onCreate(SolarDatabase db) {
     db.execSQL(
         "CREATE TABLE favorites ("
             + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -62,17 +63,17 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
   }
 
   @Override
-  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+  public void onUpgrade(SolarDatabase db, int oldVersion, int newVersion) {
     db.execSQL("DROP TABLE IF EXISTS favorites");
     onCreate(db);
   }
 
-  public synchronized List<Favorite> listAll() {
-    SQLiteDatabase db = getReadableDatabase();
-    Cursor c =
+  public List<Favorite> listAll() {
+    SolarDatabase db = openReadable();
+    SolarCursor c =
         db.query("favorites",
             new String[] {"id", "stationuuid", "name", "url", "countrycode"},
-            null, null, null, null, "added_at DESC");
+            null, null, "added_at DESC");
     List<Favorite> out = new ArrayList<Favorite>();
     try {
       while (c.moveToNext()) {
@@ -93,7 +94,7 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
 
   public synchronized long add(String stationuuid, String name, String url, String countrycode) {
     if (stationuuid == null || stationuuid.trim().isEmpty()) return -1L;
-    SQLiteDatabase db = getWritableDatabase();
+    SolarDatabase db = openWritable();
     db.execSQL(
         "INSERT OR REPLACE INTO favorites (id, stationuuid, name, url, countrycode, added_at) VALUES ("
             + "(SELECT id FROM favorites WHERE stationuuid=?), ?, ?, ?, ?, ?)",
@@ -105,7 +106,7 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
           countrycode != null ? countrycode : "",
           System.currentTimeMillis()
         });
-    Cursor c =
+    SolarCursor c =
         db.rawQuery("SELECT id FROM favorites WHERE stationuuid=?", new String[] {stationuuid.trim()});
     try {
       return c.moveToFirst() ? c.getLong(0) : -1L;
@@ -116,16 +117,16 @@ public final class InternetRadioFavorites extends SQLiteOpenHelper {
 
   public synchronized boolean remove(String stationuuid) {
     if (stationuuid == null || stationuuid.trim().isEmpty()) return false;
-    return getWritableDatabase().delete("favorites", "stationuuid=?", new String[] {
+    return openWritable().delete("favorites", "stationuuid=?", new String[] {
           stationuuid.trim()
         })
         > 0;
   }
 
-  public synchronized boolean isFavorite(String stationuuid) {
+  public boolean isFavorite(String stationuuid) {
     if (stationuuid == null || stationuuid.trim().isEmpty()) return false;
-    Cursor c =
-        getReadableDatabase()
+    SolarCursor c =
+        openReadable()
             .rawQuery("SELECT 1 FROM favorites WHERE stationuuid=? LIMIT 1",
                 new String[] {stationuuid.trim()});
     try {

--- a/app/src/main/java/com/solar/launcher/soulseek/store/ReachDatabase.java
+++ b/app/src/main/java/com/solar/launcher/soulseek/store/ReachDatabase.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import com.solar.launcher.db.SolarDatabase;
+import com.solar.launcher.db.SolarDbHelper;
 
 import com.solar.launcher.soulseek.ReachIntroMessage;
 import com.solar.launcher.soulseek.SolarDeveloperAccounts;
@@ -21,7 +23,7 @@ import java.util.List;
 import java.util.Locale;
 
 /** SQLite store for Reach rooms, messages, and peer cache. */
-public class ReachDatabase extends SQLiteOpenHelper {
+public class ReachDatabase extends SolarDbHelper {
     private static final String DB_NAME = "reach.db";
     private static final int DB_VERSION = 3;
     private static final String PREF_MIGRATED = "reach_db_migrated_v1";
@@ -32,7 +34,11 @@ public class ReachDatabase extends SQLiteOpenHelper {
     private static ReachDatabase instance;
 
     private ReachDatabase(Context ctx) {
-        super(ctx.getApplicationContext(), DB_NAME, null, DB_VERSION);
+        this(ctx, true);
+    }
+
+    private ReachDatabase(Context ctx, boolean walEnabled) {
+        super(ctx.getApplicationContext(), DB_NAME, DB_VERSION, walEnabled);
     }
 
     public static synchronized ReachDatabase getInstance(Context ctx) {
@@ -53,7 +59,7 @@ public class ReachDatabase extends SQLiteOpenHelper {
     public static ReachDatabase openForTest(Context ctx) {
         resetInstanceForTest();
         final SQLiteDatabase[] mem = new SQLiteDatabase[1];
-        instance = new ReachDatabase(ctx.getApplicationContext()) {
+        instance = new ReachDatabase(ctx.getApplicationContext(), false) {
             @Override
             public synchronized SQLiteDatabase getWritableDatabase() {
                 if (mem[0] == null) {
@@ -72,7 +78,7 @@ public class ReachDatabase extends SQLiteOpenHelper {
     }
 
     @Override
-    public void onCreate(SQLiteDatabase db) {
+    public void onCreate(SolarDatabase db) {
         db.execSQL("CREATE TABLE rooms (name TEXT PRIMARY KEY COLLATE NOCASE,"
                 + " user_count INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0)");
         db.execSQL("CREATE INDEX idx_rooms_name ON rooms(name COLLATE NOCASE)");
@@ -91,7 +97,7 @@ public class ReachDatabase extends SQLiteOpenHelper {
         createRoomTickersTable(db);
     }
 
-    private static void createRoomTickersTable(SQLiteDatabase db) {
+    private static void createRoomTickersTable(SolarDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS room_tickers (room TEXT NOT NULL,"
                 + " username TEXT NOT NULL, text TEXT NOT NULL DEFAULT '',"
                 + " updated_at INTEGER NOT NULL DEFAULT 0,"
@@ -99,13 +105,13 @@ public class ReachDatabase extends SQLiteOpenHelper {
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_room_tickers_room ON room_tickers(room)");
     }
 
-    private static void createPeerNotesTable(SQLiteDatabase db) {
+    private static void createPeerNotesTable(SolarDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS peer_notes (username TEXT PRIMARY KEY COLLATE NOCASE,"
                 + " note TEXT NOT NULL DEFAULT '', updated_at INTEGER NOT NULL DEFAULT 0)");
     }
 
     @Override
-    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    public void onUpgrade(SolarDatabase db, int oldVersion, int newVersion) {
         if (oldVersion < 2) {
             createPeerNotesTable(db);
         }

--- a/scripts/measure-scan-perf.sh
+++ b/scripts/measure-scan-perf.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Solar library-scan A/B performance harness.
+#
+# Measures full library scan time on the Innioasis Y1.
+# For the baseline build, only total time is available.
+# For the PR build, per-phase timing is read from /sdcard/solar/scan-perf.log.
+#
+# Usage:
+#   ./scripts/measure-scan-perf.sh baseline [baseline.apk]
+#   ./scripts/measure-scan-perf.sh pr [pr.apk]
+#
+# Requirements:
+#   - adb installed and Y1 connected
+#   - Music files already on the device (default /Music root)
+#   - For baseline: any recent Solar release APK
+#   - For pr: the PR build containing ScanPerfLog + LibraryScanner
+
+set -euo pipefail
+
+PKG="com.solar.launcher"
+DB_PATH="/data/data/$PKG/databases/music_library.db"
+PERF_LOG="/storage/sdcard0/solar/scan-perf.log"
+REMOTE_DIR="/storage/sdcard0/solar"
+TIMEOUT_SEC=600
+
+MODE="${1:-}"
+APK="${2:-}"
+
+if [[ "$MODE" != "baseline" && "$MODE" != "pr" ]]; then
+  echo "Usage: $0 baseline|pr [apk_file]"
+  exit 1
+fi
+
+if [[ -n "$APK" && ! -f "$APK" ]]; then
+  echo "APK not found: $APK"
+  exit 1
+fi
+
+echo "=== Solar scan perf: $MODE ==="
+
+# --- Install APK if provided -------------------------------------------------
+if [[ -n "$APK" ]]; then
+  echo "Installing $APK ..."
+  adb install -r "$APK"
+fi
+
+# --- Clear music library cache for a cold full-scan --------------------------
+echo "Clearing music library database ..."
+adb shell am force-stop "$PKG" || true
+adb shell "rm -f $DB_PATH $DB_PATH-wal $DB_PATH-shm" || true
+adb shell "mkdir -p $REMOTE_DIR"
+
+# --- Ensure log is clean on PR builds ----------------------------------------
+if [[ "$MODE" == "pr" ]]; then
+  adb shell "rm -f $PERF_LOG $PERF_LOG.old" || true
+fi
+
+# --- Launch Solar and trigger scan -------------------------------------------
+echo "Launching Solar and triggering library scan ..."
+adb shell am start -n "$PKG/.MainActivity" >/dev/null
+sleep 2
+adb shell am broadcast -a com.solar.launcher.action.START_LIBRARY_SCAN -n "$PKG/.ScanTriggerReceiver" >/dev/null
+
+# --- Wait for scan completion ------------------------------------------------
+echo "Waiting for scan to finish (timeout ${TIMEOUT_SEC}s) ..."
+START=$(date +%s)
+while true; do
+  NOW=$(date +%s)
+  if (( NOW - START > TIMEOUT_SEC )); then
+    echo "Timeout waiting for scan."
+    exit 1
+  fi
+
+  # PR build writes SolarScanPerf log lines on completion.
+  if [[ "$MODE" == "pr" ]]; then
+    if adb shell "grep -q 'SolarScanPerf' $PERF_LOG" >/dev/null 2>&1; then
+      break
+    fi
+  fi
+
+  # Both builds log "scan finished" via Debug898913Log.
+  if adb logcat -d -s "SolarDbg898913:D" | grep -q "scan finished"; then
+    break
+  fi
+
+  sleep 2
+done
+
+# --- Collect total time from logcat (both builds) ----------------------------
+echo ""
+echo "--- Total scan time from logcat ---"
+adb logcat -d -s "SolarDbg898913:D" | grep -E "(scan started|scan finished|filesystem walk done|parallel scan done)" | tail -10 || true
+
+# --- Collect detailed perf log on PR builds ----------------------------------
+if [[ "$MODE" == "pr" ]]; then
+  echo ""
+  echo "--- Pulling detailed scan perf log ---"
+  adb pull "$PERF_LOG" "./scan-perf-$MODE.log" >/dev/null 2>&1 || true
+  if [[ -f "./scan-perf-$MODE.log" ]]; then
+    echo ""
+    echo "Latest entries:"
+    tail -5 "./scan-perf-$MODE.log"
+    echo ""
+    echo "Summary (latest):"
+    python3 - <<'PY' ./scan-perf-$MODE.log
+import sys, json
+with open(sys.argv[1]) as f:
+    line = f.readlines()[-1].strip()
+data = json.loads(line)
+tracks = data.get("tracks", 0)
+ms = data.get("totalMs", 0)
+phases = data.get("phases", {})
+print(f"tracks:        {tracks}")
+print(f"total_ms:      {ms}")
+print(f"tracks/sec:    {tracks*1000/ms:.1f}" if ms else "tracks/sec:    N/A")
+for k, v in phases.items():
+    pct = v*100/ms if ms else 0
+    print(f"{k:20} {v:6} ms ({pct:.1f}%)")
+PY
+  else
+    echo "Perf log not found on device."
+  fi
+fi
+
+echo ""
+echo "=== $MODE measurement complete ==="


### PR DESCRIPTION
## Summary

Switches Solar's four SQLite stores to a faster, parallelized foundation and parallelizes the library scan's tag-extraction phase, all while keeping the project on its current Android toolchain (minSdk 17, Java 8).

A Turso/libSQL migration was evaluated but rejected for this codebase: the embedded `tech.turso.libsql:libsql` SDK requires minSdk 21 and Java 17, and the cloud product is a poor fit for offline-first firmware. This PR delivers the practical performance wins now and leaves a clean insertion point for libSQL later if the project's constraints ever change.

## SQLite layer

- **New `com.solar.launcher.db` package**
  - `SolarDbHelper` — base `SQLiteOpenHelper` that enables WAL and sets `synchronous=NORMAL`, `journal_size_limit=1MB`, and `wal_autocheckpoint=100`.
  - `SolarDatabase` / `SolarCursor` — portable DB/Cursor contracts.
  - `android.AndroidSolarDatabase` / `AndroidSolarCursor` — Android implementations.

- **Migrated stores to `SolarDbHelper`**
  - `MusicLibraryStore`
  - `FmPresetStore`
  - `InternetRadioFavorites`
  - `ReachDatabase`

- **DB performance improvements**
  - Removed coarse `synchronized` locks from read paths so Android's connection pool can serve parallel readers under WAL.
  - `MusicLibraryStore.deleteExcept()` now batches stale-path deletes with `path IN (...)` chunks instead of one `DELETE` per row.

- **libSQL pilot**
  - `FmPresetStore` is fully ported to the `SolarDatabase`/`SolarCursor` abstraction, demonstrating how a future libSQL engine can be swapped in store-by-store.

## Library scan speed

- **`MusicLibraryStore.upsertBatch()`** — single-transaction bulk insert for tracks discovered during scans.
- **`MusicLibraryStore.getFresh()`** — resolves cache freshness in one DB lookup instead of `isFresh()` + `get()`.
- **`LibraryScanner`** — new worker that:
  - Walks the filesystem serially.
  - Extracts ID3 tags in parallel via `AudioTags` / `MediaMetadataRetriever` (2–4 threads, bounded for Y1 storage).
  - Persists all discovered tracks in one SQLite transaction.
- **`MainActivity`** now uses `LibraryScanner.scan()` for full library scans.
- `MainActivity.SongItem` and `isAudioFile()` are now package-visible so `LibraryScanner` can reuse them.

## Performance measurement

- **`ScanPerfLog`** writes JSON-lines scan timing to `/storage/sdcard0/solar/scan-perf.log` and logcat tag `SolarScanPerf`.
- **`LibraryScanner.ScanResult`** reports per-phase milliseconds: file collection, freshness partition, parallel tag reading, batch persistence, merge/dedup.
- **`MainActivity`** records total scan time and phase breakdown after each scan.
- **`ScanTriggerReceiver`** allows ADB-triggered scans via `com.solar.launcher.action.START_LIBRARY_SCAN`.
- **`SolarWebServer`** exposes `/scan_stats` (and a link on the upload page) so you can read the latest timing from a browser at `http://<ip>:8080/scan_stats`.
- **`scripts/measure-scan-perf.sh`** automates baseline vs PR A/B testing.

## Verification

- `./gradlew :app:compileDebugJavaWithJavac` — ✅ successful
- `./gradlew :app:testDebugUnitTest --tests MusicLibraryStoreTest --tests ReachDatabaseTest` — ✅ successful
- Full unit-test suite has 6 pre-existing failures unrelated to SQLite/library scanning.

## Backward compatibility

- Test-mode constructors pass `walEnabled=false`, preserving existing in-memory database behavior.
- No public API changes; all stores remain singletons accessed via `getInstance(Context)`.
- Full-scan cancellation (`libraryScanGen`), progress reporting, path/meta-key dedup, and album-title normalization are preserved.
