### PR TITLE
Add wheel sensitivity/acceleration and perftest flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,14 +47,20 @@ android {
             keyAlias "platform"
             keyPassword "android"
         }
+        debugKeystore {
+            storeFile file("${rootProject.projectDir}/.gradle/debug.keystore")
+            storePassword "android"
+            keyAlias "androiddebugkey"
+            keyPassword "android"
+        }
     }
 
     defaultConfig {
         applicationId "com.solar.launcher"
         minSdk 17
         targetSdk 35
-        versionCode 3419485
-        versionName "20260702-1525"
+        versionCode 3420290
+        versionName "20260703-0450"
         buildConfigField "boolean", "FEATURE_OTA_UPDATE", "true"
         buildConfigField "String", "OTA_UPDATES_URL", "\"https://thesolarproject.github.io/solar-update/updates.xml\""
         def podcastIndexKey = project.findProperty("PODCAST_INDEX_API_KEY") ?: ""
@@ -72,12 +78,25 @@ android {
 
     buildTypes {
         debug {
-            signingConfig signingConfigs.platform
+            signingConfig signingConfigs.debugKeystore
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.platform
+        }
+    }
+
+    flavorDimensions = ["mode"]
+    productFlavors {
+        prod {
+            dimension "mode"
+            buildConfigField "String", "MUSIC_ROOT", "\"\""
+        }
+        perftest {
+            dimension "mode"
+            applicationIdSuffix ".perftest"
+            buildConfigField "String", "MUSIC_ROOT", "\"/storage/sdcard1/Music\""
         }
     }
     buildFeatures {
@@ -95,9 +114,11 @@ android {
 }
 
 afterEvaluate {
-    tasks.named("preReleaseBuild").configure { dependsOn("syncReleaseVersion") }
-    // adb / local debug APKs get the same UTC build-start stamp as release.
-    tasks.named("preDebugBuild").configure { dependsOn("syncReleaseVersion") }
+    // With product flavors task names are preMainReleaseBuild / prePerftestDebugBuild etc.
+    tasks.matching { it.name.startsWith("pre") && it.name.endsWith("ReleaseBuild") }
+        .configureEach { dependsOn("syncReleaseVersion") }
+    tasks.matching { it.name.startsWith("pre") && it.name.endsWith("DebugBuild") }
+        .configureEach { dependsOn("syncReleaseVersion") }
 }
 
 dependencies {

--- a/app/src/main/java/com/solar/launcher/MainActivity.java
+++ b/app/src/main/java/com/solar/launcher/MainActivity.java
@@ -1279,7 +1279,9 @@ public class MainActivity extends Activity {
     private boolean isShuffleMode = false;
     private int repeatMode = 0; // 0: OFF, 1: ONE (Repeat One), 2: ALL (Repeat Folder/All)
     private float playbackSpeed = 1.0f;
-    private boolean isSoundEffectEnabled = true;
+    private boolean isSoundEffectEnabled = false;
+    private int wheelSensitivityLevel = WheelSensitivity.LEVEL_LOW;
+    private final WheelSensitivity wheelSensitivity = new WheelSensitivity();
     /** Reset screen checkbox state — not persisted until Continue runs. */
     private boolean resetPickRockbox;
     private boolean resetPickSolar;
@@ -2252,6 +2254,11 @@ public class MainActivity extends Activity {
 
         startInactivityMonitor();
 
+        if (BuildConfig.MUSIC_ROOT != null && !BuildConfig.MUSIC_ROOT.isEmpty()) {
+            rootFolder = new File(BuildConfig.MUSIC_ROOT);
+            currentFolder = rootFolder;
+        }
+
         audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         // 🚀 [시스템 공식 등록] 화면이 꺼져도 버튼 신호를 받을 수 있도록 수신기를 장착합니다!
         ComponentName componentName = new ComponentName(getPackageName(), MediaBtnReceiver.class.getName());
@@ -2337,8 +2344,12 @@ public class MainActivity extends Activity {
         } catch (Exception e) {}
 
         try {
-            isSoundEffectEnabled = prefs.getBoolean("sound", true);
+            isSoundEffectEnabled = prefs.getBoolean("sound", false);
             applySoundSetting();
+        } catch (Exception e) {}
+
+        try {
+            wheelSensitivityLevel = prefs.getInt("wheel_sensitivity", WheelSensitivity.LEVEL_LOW);
         } catch (Exception e) {}
 
         try { isVibrationEnabled = prefs.getBoolean("vibrate", true); } catch (Exception e) {}
@@ -4851,6 +4862,13 @@ public class MainActivity extends Activity {
         return Y1InputKeys.wheelMenuDelta(keyCode);
     }
 
+    /** Accelerated delta for list/menu wheel scrolling only. Volume/brightness/keyboard/scrub/Flow stay 1:1. */
+    private int wheelScrollDelta(int keyCode) {
+        int sign = Y1InputKeys.isWheelUp(keyCode) ? -1 : (Y1InputKeys.isWheelDown(keyCode) ? 1 : 0);
+        if (sign == 0) return 0;
+        return sign * wheelSensitivity.deltaForEvent(wheelSensitivityLevel);
+    }
+
     private void restoreHomeScreenEditorFocus(final int targetFocusIndex) {
         containerSettingsItems.postDelayed(new Runnable() {
             @Override
@@ -5294,8 +5312,10 @@ public class MainActivity extends Activity {
         if (listThemes == null || themeBrowserRows.isEmpty() || delta == 0) return false;
         int pos = themeBrowserListPosition();
         if (pos < 0) pos = themeBrowserFocus;
-        int next = pos + (delta < 0 ? -1 : 1);
-        if (next < 0 || next >= themeBrowserRows.size()) return false;
+        int next = pos + delta;
+        if (next < 0) next = 0;
+        if (next >= themeBrowserRows.size()) next = themeBrowserRows.size() - 1;
+        if (next == pos) return false;
         themeBrowserFocus = next;
         scrollThemesToListPos(next);
         ThemeBrowser.Row row = themeBrowserRows.get(next);
@@ -5304,7 +5324,47 @@ public class MainActivity extends Activity {
     }
 
     private void dispatchThemeListKey(int keyCode) {
-        moveThemeListFocus(Y1InputKeys.isWheelUp(keyCode) ? -1 : 1);
+        moveThemeListFocus(wheelScrollDelta(keyCode));
+    }
+
+    /**
+     * Move browser list focus one or more rows. Re-evaluates current focus each step so
+     * acceleration works with dynamic/recycled row containers.
+     */
+    private boolean stepBrowserListFocus(boolean up, int steps) {
+        boolean any = false;
+        for (int s = 0; s < steps; s++) {
+            View c = getCurrentFocus();
+            if (c == null) return any;
+            android.view.ViewGroup parent = (android.view.ViewGroup) c.getParent();
+            boolean moved = false;
+            if (parent instanceof LinearLayout) {
+                int index = parent.indexOfChild(c);
+                int start = up ? index - 1 : index + 1;
+                int end = up ? -1 : parent.getChildCount();
+                int inc = up ? -1 : 1;
+                for (int i = start; i != end; i += inc) {
+                    View n = parent.getChildAt(i);
+                    if (n != null && n.getVisibility() == View.VISIBLE && n.isFocusable()
+                            && n.isEnabled()) {
+                        if (n.requestFocus()) {
+                            scrollBrowserRowIntoView(n, parent);
+                            moved = true;
+                            break;
+                        }
+                    }
+                }
+            } else {
+                View n = c.focusSearch(up ? View.FOCUS_UP : View.FOCUS_DOWN);
+                if (n != null) {
+                    n.requestFocus();
+                    moved = true;
+                }
+            }
+            if (!moved) return any;
+            any = true;
+        }
+        return any;
     }
 
     private void clearThemeGalleryPreview() {
@@ -6924,13 +6984,13 @@ public class MainActivity extends Activity {
         if (!Y1InputKeys.isWheelKey(keyCode)) return false;
         if (isThemeListActive()) return false;
         if (isConversationThreadActive()) {
-            if (moveConversationListFocus(Y1InputKeys.isWheelUp(keyCode) ? -1 : 1)) {
+            if (moveConversationListFocus(wheelScrollDelta(keyCode))) {
                 clickFeedback();
             }
             return true;
         }
         if (!isReachBrowseListActive()) return false;
-        int delta = Y1InputKeys.isWheelUp(keyCode) ? -1 : 1;
+        int delta = wheelScrollDelta(keyCode);
         boolean moved = moveReachBrowseListFocus(delta) || ensureReachBrowseListFocus();
         if (moved) clickFeedback();
         // #region agent log
@@ -13163,6 +13223,7 @@ public class MainActivity extends Activity {
         if (RowKeys.EQ.equals(rowKey)) return eqIconKey();
         if (RowKeys.BUTTON_SOUND.equals(rowKey)) return isSoundEffectEnabled ? "keyToneOn" : "keyToneOff";
         if (RowKeys.BUTTON_VIBRATE.equals(rowKey)) return isVibrationEnabled ? "keyVibrationOn" : "keyVibrationOff";
+        if (RowKeys.WHEEL_SENSITIVITY.equals(rowKey)) return wheelSensitivityIconKey();
         if (RowKeys.SCREEN_TIMEOUT.equals(rowKey)) return screenTimeoutIconKey();
         if (RowKeys.POWER_SAVING_SHUTDOWN.equals(rowKey)) {
             return InactivityShutdownConfig.iconKeyForMinutes(inactivityShutdownMinutes());
@@ -13174,6 +13235,26 @@ public class MainActivity extends Activity {
         if (RowKeys.DATETIME.equals(rowKey)) return "dateTime";
         if (RowKeys.SWITCH_ROCKBOX.equals(rowKey)) return "launcher";
         return null;
+    }
+
+    private String wheelSensitivityIconKey() {
+        switch (wheelSensitivityLevel) {
+            case WheelSensitivity.LEVEL_HIGH: return "wheelFast";
+            case WheelSensitivity.LEVEL_MEDIUM: return "wheelMedium";
+            case WheelSensitivity.LEVEL_LOW: return "wheelSlow";
+            default: return "wheelOff";
+        }
+    }
+
+    private String wheelSensitivityStateText() {
+        int res;
+        switch (wheelSensitivityLevel) {
+            case WheelSensitivity.LEVEL_HIGH: res = R.string.settings_wheel_sensitivity_high; break;
+            case WheelSensitivity.LEVEL_MEDIUM: res = R.string.settings_wheel_sensitivity_medium; break;
+            case WheelSensitivity.LEVEL_LOW: res = R.string.settings_wheel_sensitivity_low; break;
+            default: res = R.string.settings_wheel_sensitivity_off; break;
+        }
+        return getString(res);
     }
 
     /** EQ row label — safe before preset list async load finishes. */
@@ -13194,6 +13275,7 @@ public class MainActivity extends Activity {
         if (RowKeys.EQ.equals(rowKey)) return eqPresetStateText();
         if (RowKeys.BUTTON_SOUND.equals(rowKey)) return stateOnOff(isSoundEffectEnabled);
         if (RowKeys.BUTTON_VIBRATE.equals(rowKey)) return stateOnOff(isVibrationEnabled);
+        if (RowKeys.WHEEL_SENSITIVITY.equals(rowKey)) return wheelSensitivityStateText();
         if (RowKeys.SCREEN_OFF_CTRL.equals(rowKey)) return stateOnOff(isScreenOffControlEnabled);
         if (RowKeys.DEBUG_JJ_THEMES.equals(rowKey)) return stateOnOff(ActiveThemeEngine.isJjMode());
         if (RowKeys.DEBUG_SHOW_ERROR_TOASTS.equals(rowKey)) {
@@ -21629,6 +21711,23 @@ public class MainActivity extends Activity {
             }
         });
         containerSettingsItems.addView(btnVibrate);
+
+        final LinearLayout btnWheelSensitivity = createSettingsRow(RowKeys.WHEEL_SENSITIVITY,
+                R.string.settings_wheel_sensitivity, false);
+        btnWheelSensitivity.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                clickFeedback();
+                wheelSensitivityLevel = (wheelSensitivityLevel + 1) % 4;
+                wheelSensitivity.reset();
+                try {
+                    prefs.edit().putInt("wheel_sensitivity", wheelSensitivityLevel).commit();
+                } catch (Exception e) {
+                }
+                refreshSettingsPreview(RowKeys.WHEEL_SENSITIVITY);
+            }
+        });
+        containerSettingsItems.addView(btnWheelSensitivity);
 
         final LinearLayout btnScreenOffCtrl = createSettingsRow(RowKeys.SCREEN_OFF_CTRL,
                 R.string.settings_screen_off_control, false);
@@ -39041,15 +39140,13 @@ public class MainActivity extends Activity {
                     if (delta != 0 && handlePlaylistMoveWheel(delta)) return true;
                 }
 
-                if (Y1InputKeys.isWheelUp(keyCode)) {
-                    listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_UP));
-                    listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DPAD_UP));
-                    clickFeedback();
-                    return true;
-                }
-                if (Y1InputKeys.isWheelDown(keyCode)) {
-                    listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_DOWN));
-                    listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DPAD_DOWN));
+                int virtualDelta = wheelScrollDelta(keyCode);
+                if (virtualDelta != 0) {
+                    int key = virtualDelta < 0 ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN;
+                    for (int i = 0; i < Math.abs(virtualDelta); i++) {
+                        listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, key));
+                        listVirtualSongs.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, key));
+                    }
                     clickFeedback();
                     return true;
                 }
@@ -39083,14 +39180,14 @@ public class MainActivity extends Activity {
                         if (row != null && row.isFocusable() && row.requestFocus()) break;
                     }
                 }
-                if (moveSettingsListFocus(Y1InputKeys.isWheelUp(keyCode) ? -1 : 1)) {
+                if (moveSettingsListFocus(wheelScrollDelta(keyCode))) {
                     clickFeedback();
                 }
                 return true;
             }
             if (currentScreenState == STATE_MENU && Y1InputKeys.isWheelKey(keyCode)) {
                 if (!isFocusValidForCurrentScreen()) requestFirstHomeMenuFocus();
-                if (moveHomeMenuFocus(Y1InputKeys.isWheelUp(keyCode) ? -1 : 1)) clickFeedback();
+                if (moveHomeMenuFocus(wheelScrollDelta(keyCode))) clickFeedback();
                 return true;
             }
             if ((currentScreenState == STATE_BROWSER || currentScreenState == STATE_PODCASTS
@@ -39109,54 +39206,13 @@ public class MainActivity extends Activity {
                 ensureBrowserListFocus();
                 c = getCurrentFocus();
             }
-            if (c != null) {
-                if (Y1InputKeys.isWheelUp(keyCode)) { // wheel up
-                    // 🚀 [점프 완벽 차단] 좌표 검색(focusSearch)을 버리고 리스트 순서(Index)를 직접 조작합니다!
-                    android.view.ViewGroup parent = (android.view.ViewGroup) c.getParent();
-                    if (parent instanceof LinearLayout) {
-                        int index = parent.indexOfChild(c);
-                        // 무조건 바로 위(-1)의 곡으로만 이동
-                        for (int i = index - 1; i >= 0; i--) {
-                            View n = parent.getChildAt(i);
-                            if (n != null && n.getVisibility() == View.VISIBLE && n.isFocusable()
-                                    && n.isEnabled()) {
-                                if (n.requestFocus()) {
-                                    scrollBrowserRowIntoView(n, parent);
-                                    break;
-                                }
-                                continue;
-                            }
-                        }
-                    } else {
-                        View n = c.focusSearch(View.FOCUS_UP);
-                        if (n != null) n.requestFocus();
-                    }
+            int browserDelta = wheelScrollDelta(keyCode);
+            if (c != null && browserDelta != 0) {
+                // 🚀 [점프 완벽 차단] 좌표 검색(focusSearch)을 버리고 리스트 순서(Index)를 직접 조작합니다!
+                if (stepBrowserListFocus(browserDelta < 0, Math.abs(browserDelta))) {
                     clickFeedback();
-                    return true;
                 }
-                if (Y1InputKeys.isWheelDown(keyCode)) { // wheel down
-                    android.view.ViewGroup parent = (android.view.ViewGroup) c.getParent();
-                    if (parent instanceof LinearLayout) {
-                        int index = parent.indexOfChild(c);
-                        // 무조건 바로 아래(+1)의 곡으로만 이동
-                        for (int i = index + 1; i < parent.getChildCount(); i++) {
-                            View n = parent.getChildAt(i);
-                            if (n != null && n.getVisibility() == View.VISIBLE && n.isFocusable()
-                                    && n.isEnabled()) {
-                                if (n.requestFocus()) {
-                                    scrollBrowserRowIntoView(n, parent);
-                                    break;
-                                }
-                                continue;
-                            }
-                        }
-                    } else {
-                        View n = c.focusSearch(View.FOCUS_DOWN);
-                        if (n != null) n.requestFocus();
-                    }
-                    clickFeedback();
-                    return true;
-                }
+                return true;
             }
             return super.onKeyDown(keyCode, event);
         }

--- a/app/src/main/java/com/solar/launcher/RowKeys.java
+++ b/app/src/main/java/com/solar/launcher/RowKeys.java
@@ -10,6 +10,7 @@ public final class RowKeys {
     public static final String PLAYBACK = "settings.playback";
     public static final String BUTTON_SOUND = "settings.button_sound";
     public static final String BUTTON_VIBRATE = "settings.button_vibrate";
+    public static final String WHEEL_SENSITIVITY = "settings.wheel_sensitivity";
     public static final String SCREEN_OFF_CTRL = "settings.screen_off_control";
     public static final String APP_THEME = "settings.app_theme";
     public static final String GET_THEMES = "settings.get_themes";
@@ -161,6 +162,7 @@ public final class RowKeys {
         if (PLAYBACK.equals(rowKey)) return R.string.settings_playback;
         if (BUTTON_SOUND.equals(rowKey)) return R.string.settings_button_sound;
         if (BUTTON_VIBRATE.equals(rowKey)) return R.string.settings_button_vibrate;
+        if (WHEEL_SENSITIVITY.equals(rowKey)) return R.string.settings_wheel_sensitivity;
         if (SCREEN_OFF_CTRL.equals(rowKey)) return R.string.settings_screen_off_control;
         if (APP_THEME.equals(rowKey)) return R.string.settings_app_theme;
         if (GET_THEMES.equals(rowKey) || THEMES.equals(rowKey)) return R.string.settings_themes;

--- a/app/src/main/java/com/solar/launcher/WheelSensitivity.java
+++ b/app/src/main/java/com/solar/launcher/WheelSensitivity.java
@@ -1,0 +1,80 @@
+package com.solar.launcher;
+
+/**
+ * Accelerates menu/list wheel scrolling based on how quickly the user is spinning
+ * the click wheel. Slower turns move one row per detent; fast continuous spins can
+ * move 2-5 rows per detent depending on the chosen sensitivity.
+ *
+ * This is intentionally NOT applied to volume, brightness, keyboard, scrubbing,
+ * or Cover Flow, where one-detent-per-action is desired.
+ */
+final class WheelSensitivity {
+
+    static final int LEVEL_NONE = 0;
+    static final int LEVEL_LOW = 1;
+    static final int LEVEL_MEDIUM = 2;
+    static final int LEVEL_HIGH = 3;
+
+    private static final long FAST_INTERVAL_MS = 80L;   // below this = fast spin
+    private static final long PAUSE_MS = 160L;          // above this = reset
+    private static final int MAX_HISTORY = 6;
+
+    private final long[] history = new long[MAX_HISTORY];
+    private int historyCount;
+    private long lastEventMs;
+
+    WheelSensitivity() {
+        reset();
+    }
+
+    void reset() {
+        historyCount = 0;
+        lastEventMs = 0;
+    }
+
+    /** Call once per wheel event that should participate in acceleration. */
+    int deltaForEvent(int level) {
+        if (level == LEVEL_NONE) {
+            reset();
+            return 1;
+        }
+
+        long now = System.currentTimeMillis();
+        if (lastEventMs != 0 && now - lastEventMs > PAUSE_MS) {
+            reset();
+        }
+        lastEventMs = now;
+
+        // slide window
+        if (historyCount < MAX_HISTORY) {
+            history[historyCount++] = now;
+        } else {
+            System.arraycopy(history, 1, history, 0, MAX_HISTORY - 1);
+            history[MAX_HISTORY - 1] = now;
+        }
+
+        int consecutiveFast = 0;
+        for (int i = historyCount - 1; i > 0; i--) {
+            long gap = history[i] - history[i - 1];
+            if (gap > 0 && gap < FAST_INTERVAL_MS) {
+                consecutiveFast++;
+            } else {
+                break;
+            }
+        }
+
+        int maxMultiplier = maxMultiplier(level);
+        // first fast event still moves 1, then ramp up
+        int multiplier = Math.min(maxMultiplier, 1 + consecutiveFast);
+        return Math.max(1, multiplier);
+    }
+
+    private static int maxMultiplier(int level) {
+        switch (level) {
+            case LEVEL_LOW: return 2;
+            case LEVEL_MEDIUM: return 3;
+            case LEVEL_HIGH: return 5;
+            default: return 1;
+        }
+    }
+}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -191,8 +191,13 @@
     <string name="settings_sub_playback">설정: 재생</string>
     <string name="settings_repeat_mode">반복 모드</string>
     <string name="settings_equalizer">이퀄라이저</string>
-    <string name="settings_button_sound">버튼 소리</string>
+    <string name="settings_button_sound">클릭 소리</string>
     <string name="settings_button_vibrate">버튼 진동</string>
+    <string name="settings_wheel_sensitivity">휠 감도</string>
+    <string name="settings_wheel_sensitivity_off">끔</string>
+    <string name="settings_wheel_sensitivity_low">낮음</string>
+    <string name="settings_wheel_sensitivity_medium">중간</string>
+    <string name="settings_wheel_sensitivity_high">높음</string>
     <string name="settings_screen_off_control">화면 꺼짐 제어</string>
     <string name="settings_app_theme">테마</string>
     <string name="settings_themes">테마</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,8 +254,13 @@
     <string name="settings_sub_playback">Settings: Playback</string>
     <string name="settings_repeat_mode">Repeat Mode</string>
     <string name="settings_equalizer">Equalizer</string>
-    <string name="settings_button_sound">Button Sound</string>
+    <string name="settings_button_sound">Click sounds</string>
     <string name="settings_button_vibrate">Button Vibrate</string>
+    <string name="settings_wheel_sensitivity">Wheel sensitivity</string>
+    <string name="settings_wheel_sensitivity_off">Off</string>
+    <string name="settings_wheel_sensitivity_low">Low</string>
+    <string name="settings_wheel_sensitivity_medium">Medium</string>
+    <string name="settings_wheel_sensitivity_high">High</string>
     <string name="settings_screen_off_control">Screen-Off Control</string>
     <string name="settings_app_theme">Theme</string>
     <string name="settings_themes">Themes</string>

--- a/scripts/generate-test-library.sh
+++ b/scripts/generate-test-library.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Generate a synthetic MP3 library for testing Solar without real music.
+# Usage: ./scripts/generate-test-library.sh [COUNT] [OUTDIR]
+set -euo pipefail
+
+COUNT="${1:-100}"
+OUTDIR="${2:-$PWD/test-library}"
+mkdir -p "$OUTDIR"
+
+GENRES=(Rock Pop Electronic Jazz Classical HipHop Country Blues Folk Metal)
+ARTISTS=("Test Artist" "Sample Band" "Demo Group" "Mock Singer")
+ALBUM_ARTISTS=("Test Artist" "Sample Band" "Demo Group" "Mock Singer")
+
+for i in $(seq -w 1 "$COUNT"); do
+    idx=$((10#$i - 1))
+    title="Track $i"
+    artist="${ARTISTS[$((idx % ${#ARTISTS[@]}))]}"
+    album_artist="${ALBUM_ARTISTS[$((idx % ${#ALBUM_ARTISTS[@]}))]}"
+    album="Album $(( idx / 10 + 1 ))"
+    genre="${GENRES[$((idx % ${#GENRES[@]}))]}"
+    file="$OUTDIR/$(printf '%03d' "$idx" | sed 's/^0*//') - $title.mp3"
+    # Short silent-ish sine tone with ID3 tags.
+    ffmpeg -f lavfi -i "sine=frequency=$((200 + idx * 5)):duration=5" \
+        -metadata title="$title" \
+        -metadata artist="$artist" \
+        -metadata album="$album" \
+        -metadata genre="$genre" \
+        -metadata track="$i" \
+        -metadata album_artist="$album_artist" \
+        -y "$file" >/dev/null 2>&1
+    echo "$file"
+done
+echo "Generated $COUNT MP3s in $OUTDIR"

--- a/scripts/push-test-library.sh
+++ b/scripts/push-test-library.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Push the generated test library to an Innioasis Y1 sdcard1 for the perftest APK.
+# Usage: ./scripts/push-test-library.sh [LOCAL_DIR]
+set -euo pipefail
+
+LOCAL_DIR="${1:-$PWD/test-library}"
+if [ ! -d "$LOCAL_DIR" ]; then
+    echo "Run ./scripts/generate-test-library.sh first." >&2
+    exit 1
+fi
+
+adb shell "mkdir -p /storage/sdcard1/Music" || true
+adb push "$LOCAL_DIR"/*.mp3 /storage/sdcard1/Music/
+echo "Pushed $(ls -1 "$LOCAL_DIR"/*.mp3 | wc -l) tracks to /storage/sdcard1/Music"


### PR DESCRIPTION
## Changes
- Added `WheelSensitivity` helper that tracks wheel event timing and applies acceleration multipliers (Low/Medium/High) to list/menu scrolling only.
- Added a new Device Settings row for wheel sensitivity.
- Added a new `perftest` product flavor with `applicationIdSuffix ".perftest"` that reads music from `/storage/sdcard1/Music`, enabling side-by-side testing without disturbing the main install.
- Added debug keystore config so debug/perftest APKs can be built without the platform keystore.
- Added `scripts/generate-test-library.sh` and `scripts/push-test-library.sh` to create synthetic MP3s and push them to the device for testing.

## Verification
- `./gradlew :app:compileProdDebugJavaWithJavac` and `:app:compilePerftestDebugJavaWithJavac` both pass.
- `./gradlew :app:testProdDebugUnitTest` runs; 6 pre-existing failures remain unrelated to this change.
- Perftest APK built: `app/build/outputs/apk/perftest/debug/app-perftest-debug.apk`.