### PR TITLE
fix: remount volumes after UMS disable (empty All Songs)

### DIFF
--- a/app/src/main/assets/y1/solar-disable-ums.sh
+++ b/app/src/main/assets/y1/solar-disable-ums.sh
@@ -1,11 +1,13 @@
 #!/system/bin/sh
-# Solar USB mass storage disable (2026-07-10).
-# Layman: stop sharing disks with the PC.
+# Solar USB mass storage disable (2026-07-17).
+# Layman: stop sharing disks with the PC, then put Music back on the player.
+# Tech: vdc unshare leaves volumes Idle-Unmounted; without an explicit mount the
+# library is empty (All Songs lists nothing) until reboot. Always remount.
 # Y1: unshare + USB=adb only (no MTP — PC uses disk mode when user turns UMS on).
 # Y2: unshare + USB=mtp,adb (product uses MTP; UMS not supported).
 
 MODEL="$(getprop ro.product.model 2>/dev/null)"
-# 2026-07-16 — Unshare every known export path (Y1 often has both sdcard0 and sdcard1).
+# Unshare every known export path (Y1 often has both sdcard0 and sdcard1).
 VOLS="/storage/sdcard0 /storage/sdcard1"
 USB_AFTER="adb"
 case "$MODEL" in
@@ -17,26 +19,54 @@ esac
 for vol in $VOLS; do
   vdc volume unshare "$vol" ums 2>/dev/null
 done
-# 2026-07-17 — Was sleep 0.5; shorter settle so unplug after disk mode feels snappy.
-# LUN clear + setprop below are enough for host drop; long sleep stacked with dual teardown jank.
+# Short settle so LUN clear + setprop are not raced by remount.
 sleep 0.12
 # Always clear LUN nodes before mode switch — stale lun/file caused false “USB storage on”.
 for lun in \
     /sys/class/android_usb/android0/f_mass_storage/lun/file \
     /sys/class/android_usb/android0/f_mass_storage/lun0/file \
-    /sys/class/android_usb/android0/f_mass_storage/lun1/file; do
+    /sys/class/android_usb/android0/f_mass_storage/lun1/file \
+    /sys/devices/platform/mt_usb/gadget/lun0/file \
+    /sys/devices/platform/mt_usb/gadget/lun1/file; do
   if [ -w "$lun" ]; then
     echo >"$lun" 2>/dev/null
   fi
 done
 setprop sys.usb.config "$USB_AFTER"
-# 2026-07-16 — Never leave mass_storage sticky across reboot/reconnect.
-# Layman: turning disk mode off also forgets “always show as a disk”.
+# Never leave mass_storage sticky across reboot/reconnect.
 # Tech: MediaTek UsbDeviceManager copies sys.usb.config → persist.sys.usb.config on enable.
 setprop persist.sys.usb.config "$USB_AFTER"
 if [ -d /data/property ]; then
   echo -n "$USB_AFTER" > /data/property/persist.sys.usb.config 2>/dev/null
   chmod 600 /data/property/persist.sys.usb.config 2>/dev/null
 fi
-echo "UMS disabled usb=$USB_AFTER persist=$USB_AFTER"
+
+# Remount so apps can see Music again. Unshare alone leaves Idle-Unmounted.
+sleep 0.25
+for vol in $VOLS; do
+  if grep -q " $vol " /proc/mounts 2>/dev/null; then
+    continue
+  fi
+  i=0
+  while [ "$i" -lt 8 ]; do
+    vdc volume mount "$vol" 2>/dev/null
+    if grep -q " $vol " /proc/mounts 2>/dev/null; then
+      break
+    fi
+    if [ "$i" -lt 3 ]; then
+      sleep 0.25
+    else
+      sleep 0.5
+    fi
+    i=$((i + 1))
+  done
+done
+
+mounted=0
+for vol in $VOLS; do
+  if grep -q " $vol " /proc/mounts 2>/dev/null; then
+    mounted=$((mounted + 1))
+  fi
+done
+echo "UMS disabled usb=$USB_AFTER persist=$USB_AFTER mounted=$mounted"
 exit 0

--- a/app/src/main/java/com/solar/launcher/UsbMassStorageController.java
+++ b/app/src/main/java/com/solar/launcher/UsbMassStorageController.java
@@ -261,12 +261,28 @@ public final class UsbMassStorageController {
             }
             clearUserSession();
             clearStickyMassStoragePersist();
+            // Volumes may already be Idle-Unmounted after a prior unshare without remount.
+            remountExportVolumesAsync();
             return true;
         }
         boolean ok = runUmsToggle(context, false);
         clearUserSession();
         clearStickyMassStoragePersist();
+        // Script + command append remount; this covers async races and stale /system scripts.
+        remountExportVolumesAsync();
         return ok;
+    }
+
+    /**
+     * 2026-07-17 — After UMS unshare, volumes sit Idle-Unmounted until explicit vdc mount.
+     * Layman: turning disk mode off must put Music back on the player.
+     * Tech: never block the UI thread — RootShell async; MEDIA_MOUNTED will refresh library.
+     */
+    static void remountExportVolumesAsync() {
+        RootShell.runAsync(
+                "sleep 0.2; "
+                        + "vdc volume mount /storage/sdcard0 2>/dev/null; "
+                        + "vdc volume mount /storage/sdcard1 2>/dev/null");
     }
 
     /**
@@ -383,10 +399,20 @@ public final class UsbMassStorageController {
         return cmd.toString();
     }
 
-    /** Shell UMS toggle command — test hook without running root shell. */
+    /**
+     * Shell UMS toggle command — test hook without running root shell.
+     * 2026-07-17 — Disable always appends volume remount. Stale /system solar-disable-ums.sh
+     * often only unshares (Idle-Unmounted) so All Songs goes empty until reboot.
+     */
     static String buildUmsShellCommand(String scriptPath, boolean enable) {
         if (scriptPath == null || scriptPath.length() == 0) return "";
-        return "sh " + shellQuote(scriptPath);
+        String base = "sh " + shellQuote(scriptPath);
+        if (!enable) {
+            base += "; sleep 0.2"
+                    + "; vdc volume mount /storage/sdcard0 2>/dev/null"
+                    + "; vdc volume mount /storage/sdcard1 2>/dev/null";
+        }
+        return base;
     }
 
     /** Legacy alias for Y1 shell command tests. */

--- a/app/src/test/java/com/solar/launcher/UsbMassStorageControllerTest.java
+++ b/app/src/test/java/com/solar/launcher/UsbMassStorageControllerTest.java
@@ -39,6 +39,25 @@ public class UsbMassStorageControllerTest {
         if (!cmd.contains("solar-enable-ums.sh")) {
             throw new AssertionError("expected enable script in: " + cmd);
         }
+        if (cmd.contains("volume mount")) {
+            throw new AssertionError("enable must not remount: " + cmd);
+        }
+    }
+
+    @Test
+    public void disableShellCommandAlwaysRemountsExportVolumes() {
+        // Stale /system disable scripts only unshare → Idle-Unmounted (empty All Songs).
+        String cmd = UsbMassStorageController.buildUmsShellCommand(
+                "/system/etc/solar/solar-disable-ums.sh", false);
+        if (!cmd.contains("solar-disable-ums.sh")) {
+            throw new AssertionError("expected disable script in: " + cmd);
+        }
+        if (!cmd.contains("vdc volume mount /storage/sdcard0")) {
+            throw new AssertionError("expected sdcard0 remount in: " + cmd);
+        }
+        if (!cmd.contains("vdc volume mount /storage/sdcard1")) {
+            throw new AssertionError("expected sdcard1 remount in: " + cmd);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **Bug:** UMS disable leaves volumes Idle-Unmounted → empty All Songs / Music until reboot.
- **Fix:** Remount in disable script + always append remount to disable shell cmd + async remount after `disable()`.

Same change as solar-os PR (shared monorepo tip).