### PR TITLE
🧪 Add tests for OverlayShellRouter useCompanionShell

### DIFF
--- a/solar-overlay-ui/src/test/java/android/os/SystemProperties.java
+++ b/solar-overlay-ui/src/test/java/android/os/SystemProperties.java
@@ -1,0 +1,24 @@
+package android.os;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SystemProperties {
+    private static final Map<String, String> props = new HashMap<>();
+
+    public static String get(String key, String def) {
+        return props.containsKey(key) ? props.get(key) : def;
+    }
+
+    public static void set(String key, String val) {
+        if (val == null) {
+            props.remove(key);
+        } else {
+            props.put(key, val);
+        }
+    }
+
+    public static void clear() {
+        props.clear();
+    }
+}

--- a/solar-overlay-ui/src/test/java/com/solar/launcher/overlay/OverlayShellRouterTest.java
+++ b/solar-overlay-ui/src/test/java/com/solar/launcher/overlay/OverlayShellRouterTest.java
@@ -1,6 +1,8 @@
 package com.solar.launcher.overlay;
 
+import org.junit.After;
 import org.junit.Test;
+import android.os.SystemProperties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -12,9 +14,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class OverlayShellRouterTest {
 
+    @After
+    public void tearDown() {
+        SystemProperties.clear();
+    }
+
     @Test
     public void defaultUsesSolarThemedShell() {
-        // No android.os.SystemProperties on host JVM → companion_shell default 0 → Solar.
+        // android.os.SystemProperties stub is present, but empty → companion_shell default 0 → Solar.
         assertFalse(OverlayShellRouter.useCompanionShell());
         assertEquals(OverlayShellRouter.SOLAR_PKG, OverlayShellRouter.overlayPackage());
         assertEquals(OverlayShellRouter.SOLAR_OVERLAY_SERVICE,
@@ -39,5 +46,25 @@ public class OverlayShellRouterTest {
                 OverlayShellRouter.peerOverlayServiceClass());
         assertFalse(OverlayShellRouter.peerOverlayPackage()
                 .equals(OverlayShellRouter.overlayPackage()));
+    }
+
+    @Test
+    public void useCompanionShell_enabled_returnsTrue() {
+        SystemProperties.set(OverlayShellRouter.COMPANION_SHELL_PROP, "1");
+        assertTrue(OverlayShellRouter.useCompanionShell());
+    }
+
+    @Test
+    public void useCompanionShell_enabledButLegacyForced_returnsFalse() {
+        SystemProperties.set(OverlayShellRouter.COMPANION_SHELL_PROP, "1");
+        SystemProperties.set(OverlayShellRouter.LEGACY_SHELL_PROP, "1");
+        assertFalse(OverlayShellRouter.useCompanionShell());
+    }
+
+    @Test
+    public void useCompanionShell_disabledButLegacyForced_returnsFalse() {
+        SystemProperties.set(OverlayShellRouter.COMPANION_SHELL_PROP, "0");
+        SystemProperties.set(OverlayShellRouter.LEGACY_SHELL_PROP, "1");
+        assertFalse(OverlayShellRouter.useCompanionShell());
     }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for `OverlayShellRouter.useCompanionShell` and a mock for `android.os.SystemProperties`.
📊 **Coverage:** Now tests the enabled, enabled but legacy forced, and disabled but legacy forced branches.
✨ **Result:** Enhanced test coverage and stability.

---
*PR created automatically by Jules for task [13520712765954806600](https://jules.google.com/task/13520712765954806600) started by @thesolarproject*