### PR TITLE
🧪 testing improvement: Add exception test for OverlayMenuClient.startShell

### DIFF
--- a/solar-overlay-ui/build.gradle
+++ b/solar-overlay-ui/build.gradle
@@ -12,6 +12,10 @@ android {
         targetSdk 35
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -20,4 +24,5 @@ android {
 
 dependencies {
     testImplementation libs.junit
+    testImplementation 'org.mockito:mockito-core:4.11.0'
 }

--- a/solar-overlay-ui/src/test/java/com/solar/launcher/overlay/OverlayMenuClientTest.java
+++ b/solar-overlay-ui/src/test/java/com/solar/launcher/overlay/OverlayMenuClientTest.java
@@ -1,0 +1,22 @@
+package com.solar.launcher.overlay;
+
+import android.content.Context;
+import android.content.Intent;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class OverlayMenuClientTest {
+    @Test
+    public void testStartShellException() {
+        Context mockContext = mock(Context.class);
+        doThrow(new SecurityException("Mock exception")).when(mockContext).startService(any(Intent.class));
+        boolean result = OverlayMenuClient.showPowerQuickMenu(mockContext);
+        assertFalse("showPowerQuickMenu should return false when startService throws", result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added an error test for `startShell` in `OverlayMenuClient` which previously missed testing if `startService` throws an exception.
📊 **Coverage:** Now tests the scenario where `Context.startService` throws an exception, and verifies it gracefully catches it and returns `false`.
✨ **Result:** Increased code coverage and improved confidence in code reliability by correctly mocking out Context interactions using Mockito.

---
*PR created automatically by Jules for task [13749602568565362640](https://jules.google.com/task/13749602568565362640) started by @thesolarproject*