### PR TITLE
🧪 Add missing unit tests for CompanionUmsShell enable()

### DIFF
--- a/global-context-modal/build.gradle
+++ b/global-context-modal/build.gradle
@@ -78,4 +78,5 @@ android {
 dependencies {
     implementation project(':solar-overlay-ui')
     testImplementation libs.junit
+    testImplementation libs.mockitoCore
 }

--- a/global-context-modal/src/test/java/com/solar/launcher/globalcontext/CompanionUmsShellTest.java
+++ b/global-context-modal/src/test/java/com/solar/launcher/globalcontext/CompanionUmsShellTest.java
@@ -1,0 +1,109 @@
+package com.solar.launcher.globalcontext;
+
+import android.util.Log;
+
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompanionUmsShellTest {
+
+    @Test
+    public void enable_returnsTrueWhenScriptSucceedsAndExported() throws Exception {
+        Process mockProcess = mock(Process.class);
+        when(mockProcess.waitFor()).thenReturn(0);
+        Runtime mockRuntime = mock(Runtime.class);
+        when(mockRuntime.exec(any(String[].class))).thenReturn(mockProcess);
+
+        try (MockedStatic<Runtime> runtimeMock = Mockito.mockStatic(Runtime.class);
+             MockedStatic<Log> logMock = Mockito.mockStatic(Log.class);
+             MockedStatic<CompanionUmsShell> shellMock = Mockito.mockStatic(CompanionUmsShell.class, Mockito.CALLS_REAL_METHODS);
+             MockedConstruction<File> fileMock = Mockito.mockConstruction(File.class, (mock, context) -> {
+                 when(mock.isFile()).thenReturn(true);
+             })) {
+
+            runtimeMock.when(Runtime::getRuntime).thenReturn(mockRuntime);
+            logMock.when(() -> Log.w(anyString(), anyString())).thenReturn(0);
+            logMock.when(() -> Log.w(anyString(), anyString(), any(Throwable.class))).thenReturn(0);
+            logMock.when(() -> Log.i(anyString(), anyString())).thenReturn(0);
+
+            shellMock.when(CompanionUmsShell::isMassStorageExported).thenReturn(true);
+
+            assertTrue(CompanionUmsShell.enable());
+        }
+    }
+
+    @Test
+    public void enable_returnsFalseWhenScriptFails() throws Exception {
+        Process mockProcess = mock(Process.class);
+        when(mockProcess.waitFor()).thenReturn(1);
+        Runtime mockRuntime = mock(Runtime.class);
+        when(mockRuntime.exec(any(String[].class))).thenReturn(mockProcess);
+
+        try (MockedStatic<Runtime> runtimeMock = Mockito.mockStatic(Runtime.class);
+             MockedStatic<Log> logMock = Mockito.mockStatic(Log.class);
+             MockedStatic<CompanionUmsShell> shellMock = Mockito.mockStatic(CompanionUmsShell.class, Mockito.CALLS_REAL_METHODS);
+             MockedConstruction<File> fileMock = Mockito.mockConstruction(File.class, (mock, context) -> {
+                 when(mock.isFile()).thenReturn(true);
+             })) {
+
+            runtimeMock.when(Runtime::getRuntime).thenReturn(mockRuntime);
+            logMock.when(() -> Log.w(anyString(), anyString())).thenReturn(0);
+            logMock.when(() -> Log.w(anyString(), anyString(), any(Throwable.class))).thenReturn(0);
+            logMock.when(() -> Log.i(anyString(), anyString())).thenReturn(0);
+
+            shellMock.when(CompanionUmsShell::isMassStorageExported).thenReturn(true);
+
+            assertFalse(CompanionUmsShell.enable());
+        }
+    }
+
+    @Test
+    public void enable_returnsFalseWhenScriptSucceedsButNotExported() throws Exception {
+        Process mockProcess = mock(Process.class);
+        when(mockProcess.waitFor()).thenReturn(0);
+        Runtime mockRuntime = mock(Runtime.class);
+        when(mockRuntime.exec(any(String[].class))).thenReturn(mockProcess);
+
+        try (MockedStatic<Runtime> runtimeMock = Mockito.mockStatic(Runtime.class);
+             MockedStatic<Log> logMock = Mockito.mockStatic(Log.class);
+             MockedStatic<CompanionUmsShell> shellMock = Mockito.mockStatic(CompanionUmsShell.class, Mockito.CALLS_REAL_METHODS);
+             MockedConstruction<File> fileMock = Mockito.mockConstruction(File.class, (mock, context) -> {
+                 when(mock.isFile()).thenReturn(true);
+             })) {
+
+            runtimeMock.when(Runtime::getRuntime).thenReturn(mockRuntime);
+            logMock.when(() -> Log.w(anyString(), anyString())).thenReturn(0);
+            logMock.when(() -> Log.w(anyString(), anyString(), any(Throwable.class))).thenReturn(0);
+            logMock.when(() -> Log.i(anyString(), anyString())).thenReturn(0);
+
+            shellMock.when(CompanionUmsShell::isMassStorageExported).thenReturn(false);
+
+            assertFalse(CompanionUmsShell.enable());
+        }
+    }
+
+    @Test
+    public void enable_returnsFalseWhenScriptMissing() throws Exception {
+        try (MockedStatic<Log> logMock = Mockito.mockStatic(Log.class);
+             MockedStatic<CompanionUmsShell> shellMock = Mockito.mockStatic(CompanionUmsShell.class, Mockito.CALLS_REAL_METHODS);
+             MockedConstruction<File> fileMock = Mockito.mockConstruction(File.class, (mock, context) -> {
+                 when(mock.isFile()).thenReturn(false);
+             })) {
+
+            logMock.when(() -> Log.w(anyString(), anyString())).thenReturn(0);
+
+            assertFalse(CompanionUmsShell.enable());
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+mockitoCore = { group = "org.mockito", name = "mockito-core", version = "5.11.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
🎯 **What:** 
Added testing gap coverage for `CompanionUmsShell.enable()` which was missing unit tests. Testing this function was notoriously difficult because it interacts heavily with `Runtime.getRuntime().exec` and the file system. 

📊 **Coverage:**
The newly added test scenarios test the happy path and edge cases of `enable()`, mocking out external calls:
- `enable_returnsTrueWhenScriptSucceedsAndExported`: Checks success path when the script succeeds and mass storage is correctly exported.
- `enable_returnsFalseWhenScriptFails`: Verifies failure response when the executed script fails (`exitCode != 0`).
- `enable_returnsFalseWhenScriptSucceedsButNotExported`: Simulates case where the script finishes but mass storage check still fails.
- `enable_returnsFalseWhenScriptMissing`: Ensure safe fallback to `false` when no `enable` scripts are found.

✨ **Result:** 
By adding Mockito 5.11 to dependencies, we now have robust mock tests isolating Android dependencies (`Log`), Java I/O (`File.isFile`), and `Runtime` execution checks. The tests execute reliably on JVM logic safely and verify `enable` cases reliably without any flaky behavior.

---
*PR created automatically by Jules for task [15536979370280382646](https://jules.google.com/task/15536979370280382646) started by @thesolarproject*