### PR TITLE
test: clarify confusing comment in FocusScrollHelperTest

### DIFF
--- a/app/src/test/java/com/solar/launcher/FocusScrollHelperTest.java
+++ b/app/src/test/java/com/solar/launcher/FocusScrollHelperTest.java
@@ -79,7 +79,7 @@ public class FocusScrollHelperTest {
 
     @Test
     public void listSelection_secondRowStillVisible_noJumpToTop() {
-        // Classic bug: sticky-Y put row 1 at Y=0; edge-only keeps Y=45
+        // Regression test: sticky-Y used to put row 1 at Y=0; edge-only keeps Y=45
         assertEquals(45, FocusScrollHelper.computeListSelectionTop(
                 300, 45, 90, true, false, 45, 2));
     }


### PR DESCRIPTION
Fixes misleading comment that read like a bug report.

---
*PR created automatically by Jules for task [13207394947066445733](https://jules.google.com/task/13207394947066445733) started by @thesolarproject*