### PR TITLE
🔒 Fix Path Traversal in Web Server /create_folder

### DIFF
--- a/app/src/main/java/com/solar/launcher/SolarWebServer.java
+++ b/app/src/main/java/com/solar/launcher/SolarWebServer.java
@@ -211,14 +211,18 @@ public class SolarWebServer extends Thread {
                 else if (method.equals("GET") && path.startsWith("/create_folder")) {
                     String q = path.split("\\?")[1];
                     String name = URLDecoder.decode(q.split("=")[1], "UTF-8");
-                    File newDir = new File(rootFolder, name);
-                    newDir.mkdirs();
-                    newDir.setReadable(true, false);
-                    newDir.setExecutable(true, false);
-                    try { Runtime.getRuntime().exec(new String[]{"chmod", "777", newDir.getAbsolutePath()}); } catch(Exception e){}
+                    File newDir = SolarWebPaths.resolveUnder(rootFolder, name);
+                    if (newDir == null) {
+                        os.write("HTTP/1.1 400 Bad Request\r\n\r\n".getBytes("UTF-8"));
+                    } else {
+                        newDir.mkdirs();
+                        newDir.setReadable(true, false);
+                        newDir.setExecutable(true, false);
+                        try { Runtime.getRuntime().exec(new String[]{"chmod", "777", newDir.getAbsolutePath()}); } catch(Exception e){}
 
-                    String response = "HTTP/1.1 200 OK\r\n\r\nOK";
-                    os.write(response.getBytes("UTF-8"));
+                        String response = "HTTP/1.1 200 OK\r\n\r\nOK";
+                        os.write(response.getBytes("UTF-8"));
+                    }
                 }
                 else if (path.equals("/deezer") || path.startsWith("/deezer?")) {
                     if (method.equals("GET")) {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Path Traversal issue in `SolarWebServer.java` at the `/create_folder` endpoint. The user input parameter `name` was used directly in `new File(rootFolder, name)` without sanitization, allowing an attacker to traverse directories.

⚠️ **Risk:** The potential impact if left unfixed includes unauthorized creation of directories outside the designated `rootFolder`. Combined with the subsequent `chmod 777`, this could lead to arbitrary directory creation with full read/write/execute permissions on the host system.

🛡️ **Solution:** The fix replaces the unsafe `new File(rootFolder, name)` with a call to `SolarWebPaths.resolveUnder(rootFolder, name)`. This utility safely resolves the path, preventing directory traversal by rejecting absolute paths and components like `..`. A null check has been added to return a 400 Bad Request response if the resolved path is invalid (i.e. if it represents an attack).

---
*PR created automatically by Jules for task [18142120633865256985](https://jules.google.com/task/18142120633865256985) started by @thesolarproject*