### PR TITLE
🧹 Cleanup unused backup configuration XML comments

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,4 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,5 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
     </cloud-backup>
-    <!--
-    <device-transfer>
-        <include .../>
-        <exclude .../>
-    </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
🎯 **What:** Removed Android Studio-generated boilerplate TODO comments inside `app/src/main/res/xml/data_extraction_rules.xml` and `app/src/main/res/xml/backup_rules.xml`.
💡 **Why:** The boilerplate comments were marked as TODOs, causing code health alerts. Since we want default backup behavior across the app without explicitly excluding anything, keeping the XML tags empty achieves this safely and clears up the dead code.
✅ **Verification:** Verified that tests pass via `./gradlew test` with no regressions. Also, standard Android rules state that leaving the `<cloud-backup>` node empty triggers default backup behavior for all domains.
✨ **Result:** Cleaned up code health warning, simplified codebase, preserved original functionality.

---
*PR created automatically by Jules for task [12637636908207577588](https://jules.google.com/task/12637636908207577588) started by @thesolarproject*