### PR TITLE
🧹 Fix missing @Override annotation in IjkMediaPlayer

### DIFF
--- a/app/src/main/java/tv/danmaku/ijk/media/player/AbstractMediaPlayer.java
+++ b/app/src/main/java/tv/danmaku/ijk/media/player/AbstractMediaPlayer.java
@@ -118,4 +118,16 @@ public abstract class AbstractMediaPlayer implements IMediaPlayer {
     public void setDataSource(IMediaDataSource mediaDataSource) {
         throw new UnsupportedOperationException();
     }
+
+    public int getSelectedTrack(int trackType) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void selectTrack(int track) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void deselectTrack(int track) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/app/src/main/java/tv/danmaku/ijk/media/player/IMediaPlayer.java
+++ b/app/src/main/java/tv/danmaku/ijk/media/player/IMediaPlayer.java
@@ -203,6 +203,12 @@ public interface IMediaPlayer {
      */
     ITrackInfo[] getTrackInfo();
 
+    int getSelectedTrack(int trackType);
+
+    void selectTrack(int track);
+
+    void deselectTrack(int track);
+
     /*--------------------
      * AndroidMediaPlayer: ICE_CREAM_SANDWICH:
      */

--- a/app/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
+++ b/app/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
@@ -620,7 +620,7 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
         return trackInfos.toArray(new IjkTrackInfo[trackInfos.size()]);
     }
 
-    // TODO: @Override
+    @Override
     public int getSelectedTrack(int trackType) {
         switch (trackType) {
             case ITrackInfo.MEDIA_TRACK_TYPE_VIDEO:
@@ -635,13 +635,13 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
     }
 
     // experimental, should set DEFAULT_MIN_FRAMES and MAX_MIN_FRAMES to 25
-    // TODO: @Override
+    @Override
     public void selectTrack(int track) {
         _setStreamSelected(track, true);
     }
 
     // experimental, should set DEFAULT_MIN_FRAMES and MAX_MIN_FRAMES to 25
-    // TODO: @Override
+    @Override
     public void deselectTrack(int track) {
         _setStreamSelected(track, false);
     }

--- a/app/src/main/java/tv/danmaku/ijk/media/player/MediaPlayerProxy.java
+++ b/app/src/main/java/tv/danmaku/ijk/media/player/MediaPlayerProxy.java
@@ -328,6 +328,21 @@ public class MediaPlayerProxy implements IMediaPlayer {
     }
 
     @Override
+    public int getSelectedTrack(int trackType) {
+        return mBackEndMediaPlayer.getSelectedTrack(trackType);
+    }
+
+    @Override
+    public void selectTrack(int track) {
+        mBackEndMediaPlayer.selectTrack(track);
+    }
+
+    @Override
+    public void deselectTrack(int track) {
+        mBackEndMediaPlayer.deselectTrack(track);
+    }
+
+    @Override
     public void setLooping(boolean looping) {
         mBackEndMediaPlayer.setLooping(looping);
     }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Added `@Override` annotation for `deselectTrack`, `selectTrack`, and `getSelectedTrack` in `IjkMediaPlayer.java`. To ensure the code compiles, these methods were added to the `IMediaPlayer` interface, with default implementations throwing `UnsupportedOperationException` in `AbstractMediaPlayer.java` and delegation in `MediaPlayerProxy.java`.

💡 **Why:** How this improves maintainability
The missing `@Override` annotations made the code less readable and prone to typos if the interface methods were to change. By explicitly adding the interface definitions and annotations, it ensures compile-time checks and better aligns with standard Java practices.

✅ **Verification:** How you confirmed the change is safe
Tested by ensuring that `IjkMediaPlayer.java` successfully compiles with the `@Override` annotations. Tested `compileDebugJavaWithJavac` and validated all changes through code review.

✨ **Result:** The improvement achieved
The codebase is cleaner, more robust, and easier to maintain without changing any underlying functionality or breaking existing usages.

---
*PR created automatically by Jules for task [16715333670320248956](https://jules.google.com/task/16715333670320248956) started by @thesolarproject*