### PR TITLE
🔒 Fix Command Injection in Web Server /upload

### DIFF
--- a/app/src/main/java/com/solar/launcher/SolarWebServer.java
+++ b/app/src/main/java/com/solar/launcher/SolarWebServer.java
@@ -215,7 +215,7 @@ public class SolarWebServer extends Thread {
                     newDir.mkdirs();
                     newDir.setReadable(true, false);
                     newDir.setExecutable(true, false);
-                    try { Runtime.getRuntime().exec(new String[]{"chmod", "777", newDir.getAbsolutePath()}); } catch(Exception e){}
+                    newDir.setWritable(true, false);
 
                     String response = "HTTP/1.1 200 OK\r\n\r\nOK";
                     os.write(response.getBytes("UTF-8"));
@@ -581,7 +581,7 @@ public class SolarWebServer extends Thread {
                         targetDir.mkdirs();
                         targetDir.setReadable(true, false);
                         targetDir.setExecutable(true, false);
-                        try { Runtime.getRuntime().exec(new String[]{"chmod", "777", targetDir.getAbsolutePath()}); } catch(Exception e){}
+                        targetDir.setWritable(true, false);
                     }
                     File outFile = new File(targetDir, name);
 
@@ -599,7 +599,8 @@ public class SolarWebServer extends Thread {
                     fos.close();
 
                     outFile.setReadable(true, false);
-                    try { Runtime.getRuntime().exec(new String[]{"chmod", "777", outFile.getAbsolutePath()}); } catch(Exception e){}
+                    outFile.setWritable(true, false);
+                    outFile.setExecutable(true, false);
 
                     String response = "HTTP/1.1 200 OK\r\n\r\nOK";
                     os.write(response.getBytes("UTF-8"));


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `SolarWebServer.java` file uploading and directory creation functionality.
⚠️ **Risk:** The previous implementation used `Runtime.getRuntime().exec` to apply `chmod 777` to uploaded files and newly created directories. This allowed command injection if an attacker could control the filenames (e.g. creating files starting with hyphens).
🛡️ **Solution:** Removed the `Runtime.getRuntime().exec` calls and instead relied on Java's built-in File API methods (`setReadable(true, false)`, `setWritable(true, false)`, and `setExecutable(true, false)`) to achieve the identical functionality (setting wide-open permissions for all users equivalent to `chmod 777`) securely and natively.

---
*PR created automatically by Jules for task [8159613029828689216](https://jules.google.com/task/8159613029828689216) started by @thesolarproject*