### PR TITLE
🔒 Security: Restrict overly permissive export for internal receivers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,12 +110,12 @@
                 <action android:name="android.hardware.usb.action.USB_STATE" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".SolarRestartReceiver" android:exported="true">
+        <receiver android:name=".SolarRestartReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="com.solar.launcher.action.RESTART_SOLAR" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".ScanTriggerReceiver" android:exported="true">
+        <receiver android:name=".ScanTriggerReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="com.solar.launcher.action.START_LIBRARY_SCAN" />
             </intent-filter>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `AndroidManifest.xml` exposed two broadcast receivers (`ScanTriggerReceiver` and `SolarRestartReceiver`) to other apps by setting `android:exported="true"`. Both receivers execute important operations (scanning the library or restarting the application) when receiving their respective custom actions.

⚠️ **Risk:** The potential impact if left unfixed
A malicious app on the device could broadcast spoofed intents (`com.solar.launcher.action.START_LIBRARY_SCAN` or `com.solar.launcher.action.RESTART_SOLAR`) and trigger these operations continuously. This could lead to a denial of service (DoS), UI interruption, battery drain, or unexpected behavior since these operations were accessible without any permission check.

🛡️ **Solution:** How the fix addresses the vulnerability
Set `android:exported="false"` for both receivers. This prevents external components from sending intents to these receivers, ensuring they can only be triggered by components with the same user ID (i.e. the application itself or other trusted internal components), aligning with Android security best practices.

---
*PR created automatically by Jules for task [9421244060349418025](https://jules.google.com/task/9421244060349418025) started by @thesolarproject*