### PR TITLE
🧪 Add missing tests for SolarTransport

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,8 @@ android {
         applicationId "com.solar.launcher"
         minSdk 17
         targetSdk 35
-        versionCode 3451496
-        versionName "nightly-20260724-2056"
+        versionCode 3456696
+        versionName "nightly-20260728-1136"
         buildConfigField "boolean", "FEATURE_OTA_UPDATE", "true"
         buildConfigField "String", "OTA_UPDATES_URL", "\"https://thesolarproject.github.io/solar-update/updates.xml\""
         def podcastIndexKey = project.findProperty("PODCAST_INDEX_API_KEY") ?: ""
@@ -135,4 +135,12 @@ dependencies {
 // 파일 맨 밑에 추가: 최신 라이브러리 버전 체크 안전장치를 강제로 끄는 코드
 tasks.withType(com.android.build.gradle.internal.tasks.CheckAarMetadataTask).configureEach {
     enabled = false
+}
+android {
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+}
+dependencies {
+    testImplementation 'org.mockito:mockito-core:4.11.0'
 }

--- a/app/src/androidTest/java/com/solar/launcher/audio/SolarTransportDeviceTest.java
+++ b/app/src/androidTest/java/com/solar/launcher/audio/SolarTransportDeviceTest.java
@@ -1,0 +1,40 @@
+package com.solar.launcher.audio;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class SolarTransportDeviceTest {
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+        SolarTransport tx = SolarTransport.get();
+        if (tx != null) {
+            tx.shutdown();
+        }
+    }
+
+    @Test
+    public void testSingleton() {
+        SolarTransport tx1 = SolarTransport.get();
+        SolarTransport tx2 = SolarTransport.get();
+        assertNotNull(tx1);
+        assertSame(tx1, tx2);
+    }
+}

--- a/app/src/test/java/com/solar/launcher/audio/SolarTransportTest.java
+++ b/app/src/test/java/com/solar/launcher/audio/SolarTransportTest.java
@@ -1,0 +1,138 @@
+package com.solar.launcher.audio;
+
+import android.app.Application;
+import android.content.Context;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+
+import com.solar.launcher.SolarApplication;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Host checks for SolarTransport intent flags (no Robolectric).
+ * Layman: menus know immediately if play/pause was pressed, before audio thread responds.
+ */
+public class SolarTransportTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Application mockApp = Mockito.mock(Application.class);
+        Context mockAppContext = Mockito.mock(Context.class);
+        Mockito.when(mockApp.getApplicationContext()).thenReturn(mockAppContext);
+
+        java.lang.reflect.Field field = SolarApplication.class.getDeclaredField("sApp");
+        field.setAccessible(true);
+        field.set(null, mockApp);
+    }
+
+    @After
+    public void tearDown() {
+        SolarTransport tx = SolarTransport.get();
+        if (tx != null) {
+            tx.shutdown();
+        }
+    }
+
+    @Test
+    public void get_returnsSingleton() {
+        SolarTransport tx1 = SolarTransport.get();
+        SolarTransport tx2 = SolarTransport.get();
+        assertNotNull(tx1);
+        assertSame(tx1, tx2);
+    }
+
+    @Test
+    public void playFile_setsIntentSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+        File fakeFile = new File("/fake/music.mp3");
+
+        tx.playFile(fakeFile, 0, false, true);
+
+        assertTrue("ownsPlayback should be true immediately after playFile", tx.ownsPlayback());
+        assertTrue("isPlaying should be true immediately after playFile with autoStart", tx.isPlaying());
+        assertFalse("layerMode should be false", tx.isLayerMode());
+    }
+
+    @Test
+    public void playUrl_setsIntentSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+
+        tx.playUrl("http://fake.stream", 0, true);
+
+        assertTrue("ownsPlayback should be true immediately after playUrl", tx.ownsPlayback());
+        assertTrue("isPlaying should be true immediately after playUrl with autoStart", tx.isPlaying());
+        assertFalse("layerMode should be false", tx.isLayerMode());
+    }
+
+    @Test
+    public void pause_setsIntentSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+
+        tx.playFile(new File("/fake/music.mp3"), 0, false, true);
+        assertTrue(tx.isPlaying());
+
+        tx.pause();
+        assertFalse("isPlaying should be false immediately after pause", tx.isPlaying());
+        assertTrue("ownsPlayback should remain true after pause", tx.ownsPlayback());
+    }
+
+    @Test
+    public void resume_setsIntentSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+
+        tx.playFile(new File("/fake/music.mp3"), 0, false, false);
+        assertFalse(tx.isPlaying());
+
+        tx.resume();
+        assertTrue("isPlaying should be true immediately after resume", tx.isPlaying());
+        assertTrue("ownsPlayback should remain true", tx.ownsPlayback());
+    }
+
+    @Test
+    public void stop_dropsOwnershipSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+
+        tx.playFile(new File("/fake/music.mp3"), 0, false, true);
+        assertTrue(tx.isPlaying());
+
+        tx.stop();
+        assertFalse("isPlaying should be false immediately after stop", tx.isPlaying());
+        assertFalse("ownsPlayback should be false immediately after stop", tx.ownsPlayback());
+        assertFalse("layerMode should be false", tx.isLayerMode());
+    }
+
+    @Test
+    public void playLayers_setsIntentSynchronously() {
+        SolarTransport tx = SolarTransport.get();
+        File vocals = new File("/fake/vocals.mp3");
+        File instr = new File("/fake/instr.mp3");
+
+        tx.playLayers(vocals, instr, 1f, 1f, 0, true);
+
+        assertTrue("ownsPlayback should be true immediately after playLayers", tx.ownsPlayback());
+        assertTrue("isPlaying should be true immediately after playLayers with autoStart", tx.isPlaying());
+    }
+
+    @Test
+    public void shutdown_clearsSingletonInstance() {
+        SolarTransport tx1 = SolarTransport.get();
+        tx1.shutdown();
+
+        SolarTransport tx2 = SolarTransport.get();
+        assertNotSame("shutdown should clear the instance, get should return a new one", tx1, tx2);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The codebase lacked tests for `SolarTransport.java`, making it risky to refactor this complex background dual-slot audio transport layer.

📊 **Coverage:** What scenarios are now tested
- Ensuring `SolarTransport.get()` properly returns a singleton instance.
- Verified intent-setting behavior synchronously for `playFile`, `playUrl`, `pause`, `resume`, `stop`, and `playLayers`.
- Added instrumented test `SolarTransportDeviceTest` to check basic device runtime correctness of singleton.

✨ **Result:** The improvement in test coverage
Both a local unit test suite and a device instrumented test suite were introduced. By adding `mockito-core` and configuring `unitTests.returnDefaultValues = true` we successfully bypassed Android framework limitations in JVM tests without using Robolectric (which had missing JNI native deps).

---
*PR created automatically by Jules for task [1881341125761222048](https://jules.google.com/task/1881341125761222048) started by @thesolarproject*