### PR TITLE
Fix persistent tags issue in fetch track lookup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,8 +88,8 @@ android {
         applicationId "com.solar.launcher"
         minSdk 17
         targetSdk 35
-        versionCode 3474386
-        versionName "20260809-1826"
+        versionCode 3483987
+        versionName "nightly-20260816-1027"
         buildConfigField "boolean", "FEATURE_OTA_UPDATE", "true"
         buildConfigField "String", "OTA_UPDATES_URL", "\"https://thesolarproject.github.io/solar-update/updates.xml\""
         def podcastIndexKey = project.findProperty("PODCAST_INDEX_API_KEY") ?: ""

--- a/app/src/main/java/com/solar/launcher/MainActivity.java
+++ b/app/src/main/java/com/solar/launcher/MainActivity.java
@@ -62186,6 +62186,11 @@ if (OverlayKeyGate.isOverlayNavigationKey(code) || Y1InputKeys.isBackKey(code)) 
                     java.io.FileOutputStream fos = new java.io.FileOutputStream(coverFile);
                     coverBitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 90, fos);
                     fos.close();
+
+                    // After successfully fetching and saving the cover art,
+                    // attempt to embed the metadata and cover into the file permanently
+                    tryEmbedMetadataFromPrefs(track, coverFile);
+
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
@@ -62249,13 +62254,20 @@ if (OverlayKeyGate.isOverlayNavigationKey(code) || Y1InputKeys.isBackKey(code)) 
                         final String finalArtist = fetchedArtist;
                         final String finalAlbum = fetchedAlbum;
 
-                        String coverUrl = trackInfo.getJSONObject("album").getString("cover_xl").replace("https://", "http://");
-                        java.net.URL imgUrl = new java.net.URL(coverUrl);
-                        java.net.HttpURLConnection imgConn = (java.net.HttpURLConnection) imgUrl.openConnection();
-                        java.io.InputStream in = imgConn.getInputStream();
-                        final android.graphics.Bitmap coverBitmap = android.graphics.BitmapFactory.decodeStream(in);
-                        in.close();
+                        android.graphics.Bitmap tempBitmap = null;
+                        try {
+                            String coverUrl = trackInfo.getJSONObject("album").optString("cover_xl", "");
+                            if (!coverUrl.isEmpty()) {
+                                coverUrl = coverUrl.replace("https://", "http://");
+                                java.net.URL imgUrl = new java.net.URL(coverUrl);
+                                java.net.HttpURLConnection imgConn = (java.net.HttpURLConnection) imgUrl.openConnection();
+                                java.io.InputStream in = imgConn.getInputStream();
+                                tempBitmap = android.graphics.BitmapFactory.decodeStream(in);
+                                in.close();
+                            }
+                        } catch (Exception ignored) {}
 
+                        final android.graphics.Bitmap coverBitmap = tempBitmap;
                         persistFetchedMetadata(track, finalTitle, finalArtist, finalAlbum, coverBitmap);
                         final File coverFile = coverFileForTrack(track);
 
@@ -62267,7 +62279,9 @@ if (OverlayKeyGate.isOverlayNavigationKey(code) || Y1InputKeys.isBackKey(code)) 
                                     // 🚀 화면의 글씨도 즉각 공식 정보로 갈아치웁니다!
                                     tvPlayerTitle.setText(finalTitle);
                                     bindNowPlayingArtistAlbum(finalArtist, finalAlbum);
-                                    applyCachedCoverArt(coverFile.getAbsolutePath());
+                                    if (coverFile.exists()) {
+                                        applyCachedCoverArt(coverFile.getAbsolutePath());
+                                    }
                                 }
                             }
                         });


### PR DESCRIPTION
This fixes the bug where tags were not written permanently because `persistFetchedMetadata` and `fetchDeezerCoverArt` had missing calls to each other or did not execute when the cover fetch had an exception, leading to `Unknown Artist` bugs.

---
*PR created automatically by Jules for task [2655215194930995458](https://jules.google.com/task/2655215194930995458) started by @thesolarproject*